### PR TITLE
refactor(lab-3.1): align Bicep modules with bicep-standards.md

### DIFF
--- a/module-3-compute/3.1-infrastructure-as-code/bicep/main.bicep
+++ b/module-3-compute/3.1-infrastructure-as-code/bicep/main.bicep
@@ -97,10 +97,10 @@ module modDevAuthNsg 'modules/nsg.bicep' = {
   name: 'devAuthNsgDeployment'
   scope: resDevRg
   params: {
-    nsgName: 'auth-nsg'
-    location: parLocation
-    tags: union(varCommonTags, { Environment: 'Development', Purpose: 'AuthServers' })
-    securityRules: [
+    parNsgName: 'auth-nsg'
+    parLocation: parLocation
+    parTags: union(varCommonTags, { Environment: 'Development', Purpose: 'AuthServers' })
+    parSecurityRules: [
       {
         name: 'AllowBastionSSH'
         protocol: 'Tcp'
@@ -131,10 +131,10 @@ module modDevWorldNsg 'modules/nsg.bicep' = {
   name: 'devWorldNsgDeployment'
   scope: resDevRg
   params: {
-    nsgName: 'world-nsg'
-    location: parLocation
-    tags: union(varCommonTags, { Environment: 'Development', Purpose: 'WorldServers' })
-    securityRules: [
+    parNsgName: 'world-nsg'
+    parLocation: parLocation
+    parTags: union(varCommonTags, { Environment: 'Development', Purpose: 'WorldServers' })
+    parSecurityRules: [
       {
         name: 'AllowBastionSSH'
         protocol: 'Tcp'
@@ -169,17 +169,16 @@ module modHubVnet 'modules/network.bicep' = {
   name: 'hubVnetDeployment'
   scope: resPlatformRg
   params: {
-    namePrefix: 'platform-${parProject}-${varLocationShortCode}'
-    location: parLocation
-    environment: 'platform'
-    vnetAddressPrefix: parHubVnetAddressPrefix
-    subnets: [
+    parNamePrefix: 'platform-${parProject}-${varLocationShortCode}'
+    parLocation: parLocation
+    parVnetAddressPrefix: parHubVnetAddressPrefix
+    parSubnets: [
       {
         name: 'AzureBastionSubnet'
         addressPrefix: '10.0.0.0/26'
       }
     ]
-    tags: union(varCommonTags, { Environment: 'Platform', Purpose: 'HubNetwork' })
+    parTags: union(varCommonTags, { Environment: 'Platform', Purpose: 'HubNetwork' })
   }
 }
 
@@ -188,27 +187,26 @@ module modDevVnet 'modules/network.bicep' = {
   scope: resDevRg
   // dependencies inferred by Bicep from output references
   params: {
-    namePrefix: 'dev-${parProject}-${varLocationShortCode}'
-    location: parLocation
-    environment: 'dev'
-    vnetAddressPrefix: parDevVnetAddressPrefix
-    subnets: [
+    parNamePrefix: 'dev-${parProject}-${varLocationShortCode}'
+    parLocation: parLocation
+    parVnetAddressPrefix: parDevVnetAddressPrefix
+    parSubnets: [
       {
         name: 'AuthSubnet'
         addressPrefix: '10.1.1.0/24'
-        nsgId: modDevAuthNsg.outputs.nsgId
+        nsgId: modDevAuthNsg.outputs.outNsgId
       }
       {
         name: 'WorldSubnet'
         addressPrefix: '10.1.2.0/24'
-        nsgId: modDevWorldNsg.outputs.nsgId
+        nsgId: modDevWorldNsg.outputs.outNsgId
       }
       {
         name: 'DatabaseSubnet'
         addressPrefix: '10.1.3.0/24'
       }
     ]
-    tags: union(varCommonTags, { Environment: 'Development' })
+    parTags: union(varCommonTags, { Environment: 'Development' })
   }
 }
 
@@ -220,11 +218,11 @@ module modDevLbPublicIp 'modules/publicip.bicep' = {
   name: 'devLbPublicIpDeployment'
   scope: resDevRg
   params: {
-    publicIpName: 'dev-${parProject}-${varLocationShortCode}-lb-pip'
-    location: parLocation
-    sku: 'Standard'
-    allocationMethod: 'Static'
-    tags: union(varCommonTags, { Environment: 'Development', Purpose: 'LoadBalancer' })
+    parPublicIpName: 'dev-${parProject}-${varLocationShortCode}-lb-pip'
+    parLocation: parLocation
+    parSku: 'Standard'
+    parAllocationMethod: 'Static'
+    parTags: union(varCommonTags, { Environment: 'Development', Purpose: 'LoadBalancer' })
   }
 }
 
@@ -236,14 +234,14 @@ module modDevLoadBalancer 'modules/loadbalancer.bicep' = {
   name: 'devLoadBalancerDeployment'
   scope: resDevRg
   params: {
-    namePrefix: 'dev-${parProject}-${varLocationShortCode}'
-    location: parLocation
-    publicIpId: modDevLbPublicIp.outputs.publicIpId
-    backendPools: [
+    parNamePrefix: 'dev-${parProject}-${varLocationShortCode}'
+    parLocation: parLocation
+    parPublicIpId: modDevLbPublicIp.outputs.outPublicIpId
+    parBackendPools: [
       { name: 'dev-${parProject}-${varLocationShortCode}-lb-be-world' }
       { name: 'dev-${parProject}-${varLocationShortCode}-lb-be-auth' }
     ]
-    healthProbes: [
+    parHealthProbes: [
       {
         name: 'dev-${parProject}-${varLocationShortCode}-lb-probe-world'
         protocol: 'Tcp'
@@ -259,7 +257,7 @@ module modDevLoadBalancer 'modules/loadbalancer.bicep' = {
         numberOfProbes: 2
       }
     ]
-    lbRules: [
+    parLbRules: [
       {
         name: 'dev-${parProject}-${varLocationShortCode}-lb-rule-world'
         protocol: 'Tcp'
@@ -277,7 +275,7 @@ module modDevLoadBalancer 'modules/loadbalancer.bicep' = {
         probeName: 'dev-${parProject}-${varLocationShortCode}-lb-probe-auth'
       }
     ]
-    tags: union(varCommonTags, { Environment: 'Development' })
+    parTags: union(varCommonTags, { Environment: 'Development' })
   }
 }
 
@@ -289,11 +287,11 @@ output outPlatformResourceGroupName string = resPlatformRg.name
 output outDevResourceGroupName string = resDevRg.name
 output outProdResourceGroupName string = resProdRg.name
 
-output outHubVnetId string = modHubVnet.outputs.vnetId
-output outDevVnetId string = modDevVnet.outputs.vnetId
+output outHubVnetId string = modHubVnet.outputs.outVnetId
+output outDevVnetId string = modDevVnet.outputs.outVnetId
 
-output outDevLoadBalancerId string = modDevLoadBalancer.outputs.loadBalancerId
-output outDevLoadBalancerPublicIp string = modDevLbPublicIp.outputs.ipAddress
+output outDevLoadBalancerId string = modDevLoadBalancer.outputs.outLoadBalancerId
+output outDevLoadBalancerPublicIp string = modDevLbPublicIp.outputs.outIpAddress
 
 // Outputs to silence "Unused Parameter" warnings and expose config
 // output configVmSize string - Removed

--- a/module-3-compute/3.1-infrastructure-as-code/bicep/modules/loadbalancer.bicep
+++ b/module-3-compute/3.1-infrastructure-as-code/bicep/modules/loadbalancer.bicep
@@ -1,32 +1,48 @@
-// modules/loadbalancer.bicep
-// Azure Load Balancer module for high availability
+/*=====================================================
+SUMMARY: Lab 3.1 - Load Balancer Module
+DESCRIPTION: Deploys a Standard Azure Load Balancer with configurable backend pools, health probes, and LB rules for SkyCraft Lab 3.1.
+AUTHOR/S: Marcin Biszczanik
+VERSION: 1.1.0
+DEPLOYMENT: [Internal use via Orchestrator]
+======================================================*/
 
-@description('Name prefix for load balancer resources')
-param namePrefix string
+/*******************
+*    Parameters    *
+*******************/
+@description('Name prefix for load balancer resources (e.g., dev-skycraft-swc)')
+param parNamePrefix string
 
 @description('Azure region for deployment')
-param location string = resourceGroup().location
+param parLocation string = resourceGroup().location
 
-@description('Public IP address resource ID')
-param publicIpId string
+@description('Public IP address resource ID for the frontend')
+param parPublicIpId string
 
-@description('Backend pool configurations')
-param backendPools array
+@description('Backend pool configurations: [{ name }]')
+param parBackendPools array
 
-@description('Health probe configurations')
-param healthProbes array
+@description('Health probe configurations: [{ name, protocol, port, intervalInSeconds, numberOfProbes }]')
+param parHealthProbes array
 
-@description('Load balancing rule configurations')
-param lbRules array
+@description('Load balancing rule configurations: [{ name, protocol, frontendPort, backendPort, backendPoolName, probeName }]')
+param parLbRules array
 
-@description('Resource tags')
-param tags object
+@description('Resource tags (must include Project, Environment, CostCenter)')
+param parTags object
 
-// Load Balancer
-resource loadBalancer 'Microsoft.Network/loadBalancers@2023-05-01' = {
-  name: '${namePrefix}-lb'
-  location: location
-  tags: tags
+/*******************
+*    Variables     *
+*******************/
+var varLbName = '${parNamePrefix}-lb'
+var varFrontendName = '${parNamePrefix}-lb-frontend'
+
+/*******************
+*    Resources     *
+*******************/
+resource resLoadBalancer 'Microsoft.Network/loadBalancers@2023-11-01' = {
+  name: varLbName
+  location: parLocation
+  tags: parTags
   sku: {
     name: 'Standard'
     tier: 'Regional'
@@ -34,18 +50,18 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2023-05-01' = {
   properties: {
     frontendIPConfigurations: [
       {
-        name: '${namePrefix}-lb-frontend'
+        name: varFrontendName
         properties: {
           publicIPAddress: {
-            id: publicIpId
+            id: parPublicIpId
           }
         }
       }
     ]
-    backendAddressPools: [for pool in backendPools: {
+    backendAddressPools: [for pool in parBackendPools: {
       name: pool.name
     }]
-    probes: [for probe in healthProbes: {
+    probes: [for probe in parHealthProbes: {
       name: probe.name
       properties: {
         protocol: probe.protocol
@@ -54,17 +70,17 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2023-05-01' = {
         numberOfProbes: probe.numberOfProbes
       }
     }]
-    loadBalancingRules: [for (rule, i) in lbRules: {
+    loadBalancingRules: [for rule in parLbRules: {
       name: rule.name
       properties: {
         frontendIPConfiguration: {
-          id: resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', '${namePrefix}-lb', '${namePrefix}-lb-frontend')
+          id: resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', varLbName, varFrontendName)
         }
         backendAddressPool: {
-          id: resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '${namePrefix}-lb', rule.backendPoolName)
+          id: resourceId('Microsoft.Network/loadBalancers/backendAddressPools', varLbName, rule.backendPoolName)
         }
         probe: {
-          id: resourceId('Microsoft.Network/loadBalancers/probes', '${namePrefix}-lb', rule.probeName)
+          id: resourceId('Microsoft.Network/loadBalancers/probes', varLbName, rule.probeName)
         }
         protocol: rule.protocol
         frontendPort: rule.frontendPort
@@ -77,10 +93,12 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2023-05-01' = {
   }
 }
 
-// Outputs
-output loadBalancerId string = loadBalancer.id
-output loadBalancerName string = loadBalancer.name
-output backendPoolIds array = [for (pool, i) in backendPools: {
+/******************
+*     Outputs     *
+******************/
+output outLoadBalancerId string = resLoadBalancer.id
+output outLoadBalancerName string = resLoadBalancer.name
+output outBackendPoolIds array = [for (pool, i) in parBackendPools: {
   name: pool.name
-  id: loadBalancer.properties.backendAddressPools[i].id
+  id: resLoadBalancer.properties.backendAddressPools[i].id
 }]

--- a/module-3-compute/3.1-infrastructure-as-code/bicep/modules/network.bicep
+++ b/module-3-compute/3.1-infrastructure-as-code/bicep/modules/network.bicep
@@ -1,39 +1,41 @@
-// modules/network.bicep
-// Reusable network module for SkyCraft infrastructure
+/*=====================================================
+SUMMARY: Lab 3.1 - Virtual Network Module
+DESCRIPTION: Deploys a Virtual Network with configurable subnets (optionally NSG-associated) for SkyCraft Lab 3.1.
+AUTHOR/S: Marcin Biszczanik
+VERSION: 1.1.0
+DEPLOYMENT: [Internal use via Orchestrator]
+======================================================*/
 
-@description('Name prefix for network resources')
-param namePrefix string
+/*******************
+*    Parameters    *
+*******************/
+@description('Name prefix for network resources (e.g., dev-skycraft-swc)')
+param parNamePrefix string
 
 @description('Azure region for deployment')
-param location string = resourceGroup().location
-
-@description('Environment name (dev, prod)')
-@allowed(['dev', 'prod', 'platform'])
-param environment string
+param parLocation string = resourceGroup().location
 
 @description('VNet address space')
-param vnetAddressPrefix string
+param parVnetAddressPrefix string
 
-@description('Subnet configurations')
-param subnets array
+@description('Subnet configurations: [{ name, addressPrefix, nsgId? }]')
+param parSubnets array
 
-@description('Resource tags')
-param tags object = {
-  Project: 'SkyCraft'
-  Environment: environment
-  ManagedBy: 'Bicep'
-}
+@description('Resource tags (must include Project, Environment, CostCenter)')
+param parTags object
 
-// Virtual Network
-resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
-  name: '${namePrefix}-vnet'
-  location: location
-  tags: tags
+/*******************
+*    Resources     *
+*******************/
+resource resVnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: '${parNamePrefix}-vnet'
+  location: parLocation
+  tags: parTags
   properties: {
     addressSpace: {
-      addressPrefixes: [vnetAddressPrefix]
+      addressPrefixes: [parVnetAddressPrefix]
     }
-    subnets: [for subnet in subnets: {
+    subnets: [for subnet in parSubnets: {
       name: subnet.name
       properties: {
         addressPrefix: subnet.addressPrefix
@@ -45,10 +47,12 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   }
 }
 
-// Outputs
-output vnetId string = vnet.id
-output vnetName string = vnet.name
-output subnets array = [for (subnet, i) in subnets: {
+/******************
+*     Outputs     *
+******************/
+output outVnetId string = resVnet.id
+output outVnetName string = resVnet.name
+output outSubnets array = [for (subnet, i) in parSubnets: {
   name: subnet.name
-  id: vnet.properties.subnets[i].id
+  id: resVnet.properties.subnets[i].id
 }]

--- a/module-3-compute/3.1-infrastructure-as-code/bicep/modules/nsg.bicep
+++ b/module-3-compute/3.1-infrastructure-as-code/bicep/modules/nsg.bicep
@@ -1,25 +1,35 @@
-// modules/nsg.bicep
-// Network Security Group module with configurable rules
+/*=====================================================
+SUMMARY: Lab 3.1 - Network Security Group Module
+DESCRIPTION: Deploys a Network Security Group with a configurable set of security rules for SkyCraft Lab 3.1.
+AUTHOR/S: Marcin Biszczanik
+VERSION: 1.1.0
+DEPLOYMENT: [Internal use via Orchestrator]
+======================================================*/
 
+/*******************
+*    Parameters    *
+*******************/
 @description('Name of the Network Security Group')
-param nsgName string
+param parNsgName string
 
 @description('Azure region for deployment')
-param location string = resourceGroup().location
+param parLocation string = resourceGroup().location
 
 @description('Security rules configuration')
-param securityRules array = []
+param parSecurityRules array = []
 
-@description('Resource tags')
-param tags object
+@description('Resource tags (must include Project, Environment, CostCenter)')
+param parTags object
 
-// Network Security Group
-resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
-  name: nsgName
-  location: location
-  tags: tags
+/*******************
+*    Resources     *
+*******************/
+resource resNsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
+  name: parNsgName
+  location: parLocation
+  tags: parTags
   properties: {
-    securityRules: [for rule in securityRules: {
+    securityRules: [for rule in parSecurityRules: {
       name: rule.name
       properties: {
         protocol: rule.protocol
@@ -35,6 +45,8 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
   }
 }
 
-// Outputs
-output nsgId string = nsg.id
-output nsgName string = nsg.name
+/******************
+*     Outputs     *
+******************/
+output outNsgId string = resNsg.id
+output outNsgName string = resNsg.name

--- a/module-3-compute/3.1-infrastructure-as-code/bicep/modules/publicip.bicep
+++ b/module-3-compute/3.1-infrastructure-as-code/bicep/modules/publicip.bicep
@@ -1,45 +1,57 @@
-// modules/publicip.bicep
-// Public IP address module
+/*=====================================================
+SUMMARY: Lab 3.1 - Public IP Address Module
+DESCRIPTION: Deploys a Standard / Static Public IP Address for load balancers or gateways in SkyCraft Lab 3.1.
+AUTHOR/S: Marcin Biszczanik
+VERSION: 1.1.0
+DEPLOYMENT: [Internal use via Orchestrator]
+======================================================*/
 
+/*******************
+*    Parameters    *
+*******************/
 @description('Name of the public IP address')
-param publicIpName string
+param parPublicIpName string
 
 @description('Azure region for deployment')
-param location string = resourceGroup().location
+param parLocation string = resourceGroup().location
 
 @description('Public IP SKU')
 @allowed(['Basic', 'Standard'])
-param sku string = 'Standard'
+param parSku string = 'Standard'
 
 @description('IP allocation method')
 @allowed(['Static', 'Dynamic'])
-param allocationMethod string = 'Static'
+param parAllocationMethod string = 'Static'
 
-@description('DNS label (optional)')
-param dnsLabel string = ''
+@description('Optional DNS label (leave empty to skip DNS settings)')
+param parDnsLabel string = ''
 
-@description('Resource tags')
-param tags object
+@description('Resource tags (must include Project, Environment, CostCenter)')
+param parTags object
 
-// Public IP Address
-resource publicIp 'Microsoft.Network/publicIPAddresses@2023-05-01' = {
-  name: publicIpName
-  location: location
-  tags: tags
+/*******************
+*    Resources     *
+*******************/
+resource resPublicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
+  name: parPublicIpName
+  location: parLocation
+  tags: parTags
   sku: {
-    name: sku
+    name: parSku
     tier: 'Regional'
   }
   properties: {
-    publicIPAllocationMethod: allocationMethod
+    publicIPAllocationMethod: parAllocationMethod
     publicIPAddressVersion: 'IPv4'
-    dnsSettings: !empty(dnsLabel) ? {
-      domainNameLabel: dnsLabel
+    dnsSettings: !empty(parDnsLabel) ? {
+      domainNameLabel: parDnsLabel
     } : null
   }
 }
 
-// Outputs
-output publicIpId string = publicIp.id
-output publicIpName string = publicIp.name
-output ipAddress string = publicIp.properties.ipAddress
+/******************
+*     Outputs     *
+******************/
+output outPublicIpId string = resPublicIp.id
+output outPublicIpName string = resPublicIp.name
+output outIpAddress string = resPublicIp.properties.ipAddress

--- a/module-3-compute/3.1-infrastructure-as-code/tests/Standards.Tests.ps1
+++ b/module-3-compute/3.1-infrastructure-as-code/tests/Standards.Tests.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Pester 5 tests verifying Lab 3.1 Bicep files conform to SkyCraft Bicep standards.
+
+.DESCRIPTION
+    Checks the five Bicep files in Lab 3.1 against docs/bicep-standards.md:
+      - Header block (SUMMARY / DESCRIPTION / AUTHOR / VERSION / DEPLOYMENT)
+      - Hungarian notation for param / resource / module / output
+      - Resource API versions pinned to 2023-11-01 (network stack) or 2023-07-01 (RG)
+      - No preview API versions
+      - CostCenter tag present in main.bicep
+      - Compiles successfully via 'az bicep build'
+
+.EXAMPLE
+    Invoke-Pester -Path .\Standards.Tests.ps1
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.1 - Infrastructure as Code
+#>
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Discovery-phase data: -ForEach evaluates here, not in BeforeAll.
+$BicepRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\bicep')).Path
+$MainFile  = Join-Path $BicepRoot 'main.bicep'
+$ModFiles  = Get-ChildItem -Path (Join-Path $BicepRoot 'modules') -Filter '*.bicep' -File
+
+$AllCases = @(@{ file = 'main.bicep'; path = $MainFile }) +
+            ($ModFiles | ForEach-Object { @{ file = $_.Name; path = $_.FullName } })
+$ModCases = $ModFiles | ForEach-Object { @{ file = $_.Name; path = $_.FullName } }
+
+Describe 'Lab 3.1 Bicep - file header' {
+    It "'<file>' has the standard SUMMARY header" -ForEach $AllCases {
+        $head = (Get-Content -LiteralPath $path -TotalCount 8) -join "`n"
+        $head | Should -Match 'SUMMARY:'
+        $head | Should -Match 'DESCRIPTION:'
+        $head | Should -Match 'AUTHOR/S:'
+        $head | Should -Match 'VERSION:'
+    }
+}
+
+Describe 'Lab 3.1 Bicep - Hungarian notation' {
+    It "'<file>' uses par<Name> for every declared parameter" -ForEach $AllCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $bad = [regex]::Matches($text, '(?m)^param\s+(\w+)') |
+               Where-Object { $_.Groups[1].Value -notmatch '^par[A-Z]' } |
+               ForEach-Object { $_.Groups[1].Value }
+        $bad | Should -BeNullOrEmpty -Because "parameters must start with 'par'; offenders: $($bad -join ', ')"
+    }
+
+    It "'<file>' uses res<Name> for every resource symbol" -ForEach $AllCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $bad = [regex]::Matches($text, "(?m)^resource\s+(\w+)\s+'") |
+               Where-Object { $_.Groups[1].Value -notmatch '^res[A-Z]' } |
+               ForEach-Object { $_.Groups[1].Value }
+        $bad | Should -BeNullOrEmpty -Because "resources must start with 'res'; offenders: $($bad -join ', ')"
+    }
+
+    It "'<file>' uses mod<Name> for every module symbol" -ForEach $AllCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $bad = [regex]::Matches($text, "(?m)^module\s+(\w+)\s+'") |
+               Where-Object { $_.Groups[1].Value -notmatch '^mod[A-Z]' } |
+               ForEach-Object { $_.Groups[1].Value }
+        $bad | Should -BeNullOrEmpty -Because "modules must start with 'mod'; offenders: $($bad -join ', ')"
+    }
+
+    It "'<file>' uses out<Name> for every output symbol" -ForEach $AllCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $bad = [regex]::Matches($text, '(?m)^output\s+(\w+)\s') |
+               Where-Object { $_.Groups[1].Value -notmatch '^out[A-Z]' } |
+               ForEach-Object { $_.Groups[1].Value }
+        $bad | Should -BeNullOrEmpty -Because "outputs must start with 'out'; offenders: $($bad -join ', ')"
+    }
+}
+
+Describe 'Lab 3.1 Bicep - API versions' {
+    It "'<file>' pins resource APIs to 2023-11-01 and uses no preview versions" -ForEach $ModCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $apis = [regex]::Matches($text, "'Microsoft\.[A-Za-z]+/[A-Za-z]+@([0-9-]+(?:-preview)?)'") |
+                ForEach-Object { $_.Groups[1].Value } |
+                Sort-Object -Unique
+        $apis | Should -Not -BeNullOrEmpty
+        foreach ($api in $apis) {
+            $api | Should -Not -Match 'preview' -Because "preview APIs violate bicep-standards.md §2 in '$file'"
+            $api | Should -Be '2023-11-01' -Because "Lab 2 gold standard is 2023-11-01 in '$file'"
+        }
+    }
+}
+
+Describe 'Lab 3.1 Bicep - CostCenter tag coverage' {
+    BeforeAll {
+        $script:MainFile = (Resolve-Path (Join-Path $PSScriptRoot '..\bicep\main.bicep')).Path
+    }
+
+    It 'main.bicep defines CostCenter in varCommonTags' {
+        Get-Content -Raw -LiteralPath $script:MainFile | Should -Match 'CostCenter'
+    }
+
+    It 'main.bicep is not relying on ManagedBy instead of CostCenter' {
+        $text = Get-Content -Raw -LiteralPath $script:MainFile
+        if ($text -match 'ManagedBy') {
+            $text | Should -Match 'CostCenter' -Because 'ManagedBy is OK as extra metadata, but CostCenter must also be present'
+        }
+    }
+}
+
+Describe 'Lab 3.1 Bicep - compilation' {
+    It "'<file>' compiles via 'az bicep build'" -ForEach $AllCases {
+        $null = & az bicep build --file $path --stdout 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because "'$file' must compile without errors"
+    }
+}


### PR DESCRIPTION
## Summary

Brings the four modules under `module-3-compute/3.1-infrastructure-as-code/bicep/modules/` in line with `docs/bicep-standards.md`. They were authored before the standards were formalised and drifted from them.

Per module (`loadbalancer.bicep`, `network.bicep`, `nsg.bicep`, `publicip.bicep`):

- Add the standard `SUMMARY / DESCRIPTION / AUTHOR/S / VERSION / DEPLOYMENT` header block (§1)
- Rename parameters → `par<Name>`, resources → `res<Name>`, outputs → `out<Name>` (§3 Hungarian notation)
- Drop the local default tag block that referenced `ManagedBy` without the policy-required `CostCenter`; callers now always pass `parTags`
- Upgrade API versions `2023-05-01` → `2023-11-01` to match the Lab 2 gold standard (§2)
- Remove the unused `parEnvironment` parameter from `network.bicep`
- Extract the load-balancer name into a `var` for `resourceId()` reuse

`main.bicep` was rewired to pass the renamed parameters and consume the renamed outputs (`modDevAuthNsg.outputs.outNsgId`, `modHubVnet.outputs.outVnetId`, etc.).

## Why

The four sub-modules were the only Bicep files in the repo violating every major §-rule (Hungarian, header, API, required tags). New contributors copying them forward would propagate the divergence.

## Test plan

- [x] `Invoke-Pester -Path module-3-compute/3.1-infrastructure-as-code/tests/Standards.Tests.ps1` → **36/36 pass** (verified locally 2026-05-26, Pester 5.7.1, PowerShell 7)
- [x] `az bicep build` clean for `main.bicep` + 4 modules (covered by the Pester suite)
- [x] Subscription-scope What-If on the real Azure subscription → `status: Succeeded`, no errors (verified 2026-05-26 via `az deployment sub what-if --location swedencentral --template-file main.bicep --parameters parameters/dev.bicepparam`)