### PR TITLE
docs(ps): bring Comment-Based Help to 100% coverage across scripts

### DIFF
--- a/module-1-identities-governance/1.2-rbac/scripts/New-LabResourceGroup.ps1
+++ b/module-1-identities-governance/1.2-rbac/scripts/New-LabResourceGroup.ps1
@@ -1,12 +1,46 @@
-# Lab 1.2 - Resource Groups Creation Script
-# This script creates resource groups
+<#
+.SYNOPSIS
+    Creates the three SkyCraft resource groups (dev / prod / platform) in Sweden Central.
 
+.DESCRIPTION
+    Idempotently creates the resource groups required by Lab 1.2 and stamps each one
+    with the mandatory governance tags (Project, Environment, CostCenter). Skips
+    groups that already exist. Use -WhatIf to print planned actions without making changes.
+
+.PARAMETER SubscriptionId
+    The target Azure Subscription ID. Mandatory — the script switches context to it before
+    creating any resource groups.
+
+.PARAMETER Location
+    Azure region for all three resource groups. Defaults to 'Sweden Central'.
+
+.PARAMETER WhatIf
+    If specified, prints the resource groups that would be created without actually creating them.
+
+.EXAMPLE
+    .\New-LabResourceGroup.ps1 -SubscriptionId '00000000-0000-0000-0000-000000000000'
+    Creates dev/prod/platform resource groups in Sweden Central.
+
+.EXAMPLE
+    .\New-LabResourceGroup.ps1 -SubscriptionId $subId -WhatIf
+    Prints the planned resource groups without creating anything.
+
+.NOTES
+    Project: SkyCraft
+    Lab: 1.2 - RBAC
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
+#>
+
+[CmdletBinding(SupportsShouldProcess = $false)]
 param(
     [Parameter(Mandatory = $true)]
     [string]$SubscriptionId,
 
+    [Parameter(Mandatory = $false)]
     [string]$Location = "Sweden Central",
 
+    [Parameter(Mandatory = $false)]
     [switch]$WhatIf
 )
 

--- a/module-2-networking/2.3-name-resolution/scripts/Deploy-Bicep.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Deploy-Bicep.ps1
@@ -1,3 +1,31 @@
+<#
+.SYNOPSIS
+    Deploys Lab 2.3 name resolution and load balancer infrastructure via Bicep.
+
+.DESCRIPTION
+    Runs an Azure subscription-scoped deployment of the Lab 2.3 main.bicep template, which
+    provisions public and private DNS zones, VNet links, A/CNAME records, and dev/prod load
+    balancers. The deployment name is stamped with the current timestamp so successive runs
+    do not overwrite each other in the deployment history.
+
+.PARAMETER Location
+    The Azure region for the subscription-scoped deployment. Defaults to 'swedencentral'.
+
+.PARAMETER TemplateFile
+    Path to the Bicep template to deploy. Defaults to '..\bicep\main.bicep' (relative to
+    this script's folder).
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1
+    Deploys the default main.bicep to Sweden Central using the current Az context.
+
+.NOTES
+    Project: SkyCraft
+    Lab: 2.3 - Name Resolution & Load Balancing
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
+#>
+
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]

--- a/module-2-networking/2.3-name-resolution/scripts/Deploy-DNS.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Deploy-DNS.ps1
@@ -7,6 +7,12 @@
     1. Create Public DNS Zone (skycraft.example.com) & Records.
     2. Create Private DNS Zone (skycraft.internal) & Records.
     3. Link Private DNS to VNets (Hub, Dev, Prod).
+
+.NOTES
+    Project: SkyCraft
+    Lab: 2.3 - Name Resolution & Load Balancing
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-2-networking/2.3-name-resolution/scripts/Deploy-LoadBalancer.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Deploy-LoadBalancer.ps1
@@ -7,6 +7,12 @@
     1. Deploy Standard Public Load Balancer for Dev.
     2. Deploy Standard Public Load Balancer for Prod.
     3. Configure Backend Pools, Health Probes, and Rules.
+
+.NOTES
+    Project: SkyCraft
+    Lab: 2.3 - Name Resolution & Load Balancing
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-2-networking/2.3-name-resolution/scripts/Remove-LabResource.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Remove-LabResource.ps1
@@ -1,3 +1,44 @@
+<#
+.SYNOPSIS
+    Removes Lab 2.3 DNS zones, VNet links, and dev/prod load balancers.
+
+.DESCRIPTION
+    Cleanup script for Lab 2.3. Removes resources in the safe order: public DNS zone,
+    both load balancers, private DNS VNet links, private DNS zone. Each removal is
+    guarded by a Get-* existence check so the script is idempotent and can be re-run.
+
+.PARAMETER PublicDnsZoneName
+    Public DNS zone to delete. Defaults to 'skycraft.example.com'.
+
+.PARAMETER PrivateDnsZoneName
+    Private DNS zone to delete. Defaults to 'skycraft.internal'.
+
+.PARAMETER PlatformRG
+    Resource group that hosts the DNS zones. Defaults to 'platform-skycraft-swc-rg'.
+
+.PARAMETER DevRG
+    Resource group that hosts the dev load balancer. Defaults to 'dev-skycraft-swc-rg'.
+
+.PARAMETER ProdRG
+    Resource group that hosts the prod load balancer. Defaults to 'prod-skycraft-swc-rg'.
+
+.PARAMETER DevLbName
+    Name of the dev load balancer. Defaults to 'dev-skycraft-swc-lb'.
+
+.PARAMETER ProdLbName
+    Name of the prod load balancer. Defaults to 'prod-skycraft-swc-lb'.
+
+.EXAMPLE
+    .\Remove-LabResource.ps1
+    Removes all Lab 2.3 DNS and load balancer resources using the default names.
+
+.NOTES
+    Project: SkyCraft
+    Lab: 2.3 - Name Resolution & Load Balancing
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
+#>
+
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]

--- a/module-2-networking/2.3-name-resolution/scripts/Test-Lab.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Test-Lab.ps1
@@ -1,3 +1,25 @@
+<#
+.SYNOPSIS
+    Validates Lab 2.3 DNS zones, links, records, and load balancers.
+
+.DESCRIPTION
+    Runs a set of read-only checks against the deployed Lab 2.3 resources and prints a
+    pass/fail summary. Exits with a non-zero code if any validation fails. Checks:
+      - Public DNS zone and required A / CNAME records
+      - Private DNS zone and hub / dev / prod VNet links with the expected registration flag
+      - Dev and prod load balancers have Standard SKU, >=2 probes and >=2 LB rules
+
+.EXAMPLE
+    .\Test-Lab.ps1
+    Runs all Lab 2.3 validations using the current Az context.
+
+.NOTES
+    Project: SkyCraft
+    Lab: 2.3 - Name Resolution & Load Balancing
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
+#>
+
 [CmdletBinding()]
 param()
 

--- a/module-3-compute/3.1-infrastructure-as-code/scripts/Export-ARM.ps1
+++ b/module-3-compute/3.1-infrastructure-as-code/scripts/Export-ARM.ps1
@@ -10,6 +10,12 @@
 
 .PARAMETER OutputFile
     Path to save the JSON file. Default: 'exported-template.json'
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.1 - Infrastructure as Code
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-3-compute/3.1-infrastructure-as-code/scripts/Remove-LabResource.ps1
+++ b/module-3-compute/3.1-infrastructure-as-code/scripts/Remove-LabResource.ps1
@@ -12,6 +12,12 @@
 
 .EXAMPLE
     .\Cleanup-Resources.ps1 -Environment all
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.1 - Infrastructure as Code
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-3-compute/3.1-infrastructure-as-code/scripts/Test-Lab.ps1
+++ b/module-3-compute/3.1-infrastructure-as-code/scripts/Test-Lab.ps1
@@ -14,6 +14,12 @@
 
 .EXAMPLE
     .\Test-Lab.ps1 -Environment dev
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.1 - Infrastructure as Code
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1
@@ -32,6 +32,12 @@
 
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment dev -EncryptionStrategy AzureDiskEncryption -WhatIf
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.2 - Virtual Machines
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-3-compute/3.2-virtual-machines/scripts/Remove-LabResource.ps1
+++ b/module-3-compute/3.2-virtual-machines/scripts/Remove-LabResource.ps1
@@ -24,6 +24,12 @@
     
 .EXAMPLE
     .\Remove-LabResource.ps1 -Environment dev -Force -IncludeKeyVault
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.2 - Virtual Machines
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/module-3-compute/3.2-virtual-machines/scripts/Test-Lab.ps1
+++ b/module-3-compute/3.2-virtual-machines/scripts/Test-Lab.ps1
@@ -14,6 +14,12 @@
 
 .EXAMPLE
     .\Test-Lab.ps1 -Environment dev
+
+.NOTES
+    Project: SkyCraft
+    Lab: 3.2 - Virtual Machines
+    Author: Marcin Biszczanik
+    Date: 2026-01-11
 #>
 
 [CmdletBinding()]

--- a/tests/Cbh-Coverage.Tests.ps1
+++ b/tests/Cbh-Coverage.Tests.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS
+    Pester 5 test: every PowerShell script in the repo ships Comment-Based Help.
+
+.DESCRIPTION
+    docs/powershell-standards.md §1 requires every *.ps1 under module-*/**/scripts/ to carry
+    a Comment-Based Help block with .SYNOPSIS, .DESCRIPTION, and .NOTES. This test finds
+    every such script and asserts those three tags are present in the first 60 lines.
+
+.EXAMPLE
+    Invoke-Pester -Path .\tests\Cbh-Coverage.Tests.ps1
+
+.NOTES
+    Project: SkyCraft
+#>
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+$RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$PsScripts  = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.ps1' |
+              Where-Object { $_.FullName -match '\\module-\d.*\\scripts\\' }
+
+$ScriptCases = $PsScripts | ForEach-Object {
+    @{ file = $_.FullName.Substring($RepoRoot.Length + 1); path = $_.FullName }
+}
+
+Describe 'SkyCraft PowerShell - CBH coverage' {
+    It "'<file>' contains a .SYNOPSIS tag in the first 60 lines" -ForEach $ScriptCases {
+        $head = (Get-Content -LiteralPath $path -TotalCount 60) -join "`n"
+        $head | Should -Match '\.SYNOPSIS'
+    }
+
+    It "'<file>' contains a .DESCRIPTION tag in the first 60 lines" -ForEach $ScriptCases {
+        $head = (Get-Content -LiteralPath $path -TotalCount 60) -join "`n"
+        $head | Should -Match '\.DESCRIPTION'
+    }
+
+    It "'<file>' contains a .NOTES tag in the first 60 lines" -ForEach $ScriptCases {
+        $head = (Get-Content -LiteralPath $path -TotalCount 60) -join "`n"
+        $head | Should -Match '\.NOTES'
+    }
+}


### PR DESCRIPTION
## Summary

`docs/powershell-standards.md` §1 requires every script to ship a `.SYNOPSIS / .DESCRIPTION / .NOTES` block. The original audit found four scripts with no CBH at all; the Pester test added here also caught eight more that had `.SYNOPSIS / .DESCRIPTION` but were missing `.NOTES`. Both groups are fixed.

**Full CBH added** (previously had no CBH):
- `module-1-identities-governance/1.2-rbac/scripts/New-LabResourceGroup.ps1`
- `module-2-networking/2.3-name-resolution/scripts/{Deploy-Bicep,Remove-LabResource,Test-Lab}.ps1`

**`.NOTES` block appended** (already had `.SYNOPSIS + .DESCRIPTION`):
- `module-2-networking/2.3-name-resolution/scripts/{Deploy-DNS,Deploy-LoadBalancer}.ps1`
- `module-3-compute/3.1-infrastructure-as-code/scripts/{Export-ARM,Remove-LabResource,Test-Lab}.ps1`
- `module-3-compute/3.2-virtual-machines/scripts/{Deploy-Bicep,Remove-LabResource,Test-Lab}.ps1`

## Why

Missing CBH blocks were a silent drift from `powershell-standards.md`. They don't break anything operationally but they break `Get-Help` and reduce the pedagogical value — every learner opening a script should see its intent plus lab context up top.

## Test plan

- [x] `Invoke-Pester -Path tests/Cbh-Coverage.Tests.ps1` → 189/189 pass across 63 scripts
- [x] `Get-Help .\New-LabResourceGroup.ps1 -Full` renders cleanly