### PR TITLE
docs(module-1): add Architecture Overview with Mermaid diagram

### DIFF
--- a/module-1-identities-governance/README.MD
+++ b/module-1-identities-governance/README.MD
@@ -37,6 +37,61 @@ By completing this module, you will be able to:
 
 ---
 
+## 🏗️ Architecture Overview
+
+This module establishes the identity and governance layer that every subsequent module depends on. Entra ID users are placed into security groups, the groups are bound to built-in Azure roles via RBAC, and Azure Policy / locks / budgets are applied to the three SkyCraft resource groups at the subscription level.
+
+```mermaid
+graph TB
+    subgraph "Microsoft Entra ID tenant"
+        UserMal["Malfurion Stormrage<br/>(Owner — Global Admin)"]
+        UserKhad["Khadgar Archmage<br/>(Contributor)"]
+        UserChrom["Chromie Timewalker<br/>(Reader)"]
+        UserIll["Illidan Stormrage<br/>(Guest)"]
+        GAdmin["SkyCraft-Admins"]
+        GDev["SkyCraft-Developers"]
+        GTest["SkyCraft-Testers"]
+        UserMal --> GAdmin
+        UserKhad --> GDev
+        UserChrom --> GTest
+    end
+
+    subgraph "Azure Subscription — governance"
+        Policy["Azure Policy<br/>(naming / SKU / tag required)"]
+        Budget["Budgets & Cost Alerts<br/>(MSDN)"]
+        Locks["Resource Locks<br/>(CanNotDelete on Prod)"]
+    end
+
+    subgraph "Resource Groups (scopes)"
+        RGPlatform["platform-skycraft-swc-rg"]
+        RGDev["dev-skycraft-swc-rg"]
+        RGProd["prod-skycraft-swc-rg"]
+    end
+
+    GAdmin -->|Owner| RGPlatform
+    GAdmin -->|Owner| RGDev
+    GAdmin -->|Owner| RGProd
+    GDev -->|Contributor| RGDev
+    GTest -->|Reader| RGDev
+    GTest -->|Reader| RGProd
+    UserIll -->|Guest, limited| RGPlatform
+
+    Policy --> RGPlatform
+    Policy --> RGDev
+    Policy --> RGProd
+    Budget --> RGProd
+    Locks --> RGProd
+
+    style RGPlatform fill:#e1f5ff,stroke:#0078d4,stroke-width:3px
+    style RGDev fill:#fff4e1,stroke:#f39c12,stroke-width:2px
+    style RGProd fill:#ffe1e1,stroke:#e74c3c,stroke-width:2px
+    style GAdmin fill:#e8f5e9
+    style GDev fill:#e8f5e9
+    style GTest fill:#e8f5e9
+```
+
+---
+
 ## ✅ Prerequisites
 
 Before starting, ensure you have:

--- a/module-1-identities-governance/tests/Readme-Architecture.Tests.ps1
+++ b/module-1-identities-governance/tests/Readme-Architecture.Tests.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Pester 5 test: Module 1 README ships the required Architecture Overview section.
+
+.DESCRIPTION
+    docs/project-standards.md §1.1 (L004) requires every module README to carry a
+    '🏗️ Architecture Overview' section with a Mermaid diagram as section #4 (between
+    '📋 Module Sections' and '✅ Prerequisites'). This test asserts that contract
+    on module-1-identities-governance/README.MD.
+
+.EXAMPLE
+    Invoke-Pester -Path .\Readme-Architecture.Tests.ps1
+
+.NOTES
+    Project: SkyCraft
+    Module: 1 - Identities & Governance
+#>
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeAll {
+    $script:ReadmePath = (Resolve-Path (Join-Path $PSScriptRoot '..\README.MD')).Path
+    $script:Text       = Get-Content -Raw -LiteralPath $script:ReadmePath
+    $script:Headings   = Get-Content -LiteralPath $script:ReadmePath |
+                         Where-Object { $_ -match '^##\s+' } |
+                         ForEach-Object { $_ -replace '^##\s+', '' }
+}
+
+Describe 'Module 1 README - L004 Architecture Overview' {
+    It 'defines an Architecture Overview section with the required emoji' {
+        ($script:Text) | Should -Match '##\s+🏗️\s+Architecture Overview'
+    }
+
+    It 'places Architecture Overview as section #4' {
+        $script:Headings.Count | Should -BeGreaterOrEqual 4
+        $script:Headings[3] | Should -Match '🏗️'
+        $script:Headings[3] | Should -Match 'Architecture Overview'
+    }
+
+    It 'embeds a Mermaid code block in the README' {
+        $script:Text | Should -Match '```mermaid'
+    }
+
+    It 'references the three SkyCraft resource groups in the diagram' {
+        $script:Text | Should -Match 'platform-skycraft-swc-rg'
+        $script:Text | Should -Match 'dev-skycraft-swc-rg'
+        $script:Text | Should -Match 'prod-skycraft-swc-rg'
+    }
+
+    It 'references at least one Warcraft persona from the framework' {
+        $script:Text | Should -Match '(Malfurion|Khadgar|Chromie|Illidan)'
+    }
+}


### PR DESCRIPTION
## Summary

`module-1-identities-governance/README.md` was the only module README missing the `🏗️ Architecture Overview` section required as L004 section #4 (`docs/project-standards.md` §1.1). All four other modules carry one.

This PR inserts the section between `Module Sections` and `Prerequisites` with a Mermaid diagram showing:

- the four Warcraft personas and their role assignments
- the three Entra security groups and their bindings
- the subscription-level governance layer (Policy / Budgets / Locks)
- the three SkyCraft resource groups with the standard colour palette (Platform blue, Dev orange, Prod red) from `lab-guide-standards.md` §3

## Why

Closes the last L004 gap so every module README is uniformly navigable.

## Test plan

- [x] `Invoke-Pester -Path module-1-identities-governance/tests/Readme-Architecture.Tests.ps1` → 5/5 pass
- [x] Mermaid diagram renders correctly in GitHub preview