### PR TITLE
refactor(lab-3.3,3.4): downgrade bleeding-edge Bicep API versions to stable

### DIFF
--- a/module-3-compute/3.3-containers/bicep/modules/aci.bicep
+++ b/module-3-compute/3.3-containers/bicep/modules/aci.bicep
@@ -41,7 +41,7 @@ var varDnsLabel = toLower('${parAciName}-${uniqueString(resourceGroup().id)}')
 *******************/
 
 // Reference existing ACR to get credentials
-resource resAcr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+resource resAcr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
   name: parAcrName
 }
 

--- a/module-3-compute/3.3-containers/bicep/modules/acr.bicep
+++ b/module-3-compute/3.3-containers/bicep/modules/acr.bicep
@@ -34,7 +34,7 @@ var varAcrNameStart = toLower(parAcrName)
 *******************/
 
 // ACR - Standard SKU with Admin enabled
-resource resAcr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' = {
+resource resAcr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   name: varAcrNameStart
   location: parLocation
   tags: varCommonTags

--- a/module-3-compute/3.3-containers/bicep/modules/containerapps.bicep
+++ b/module-3-compute/3.3-containers/bicep/modules/containerapps.bicep
@@ -41,7 +41,7 @@ var varCommonTags = {
 *******************/
 
 // ACR Reference for Credentials
-resource resAcr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+resource resAcr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
   name: parAcrName
 }
 

--- a/module-3-compute/3.4-app-service/bicep/modules/app-service.bicep
+++ b/module-3-compute/3.4-app-service/bicep/modules/app-service.bicep
@@ -37,7 +37,7 @@ var varCommonTags = {
 *    Resources     *
 *******************/
 
-resource resAppServicePlan 'Microsoft.Web/serverfarms@2025-03-01' = {
+resource resAppServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: parAppServicePlanName
   location: parLocation
   tags: varCommonTags
@@ -54,7 +54,7 @@ resource resAppServicePlan 'Microsoft.Web/serverfarms@2025-03-01' = {
   }
 }
 
-resource resWebApp 'Microsoft.Web/sites@2025-03-01' = {
+resource resWebApp 'Microsoft.Web/sites@2023-12-01' = {
   name: parAppName
   location: parLocation
   tags: varCommonTags

--- a/tests/Api-Version-Policy.Tests.ps1
+++ b/tests/Api-Version-Policy.Tests.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Pester 5 tests: every Bicep file pins a stable, non-future API version.
+
+.DESCRIPTION
+    docs/bicep-standards.md §2 requires "Gold Standard" stable API versions and forbids
+    bleeding-edge releases ("Prefer Stable Versions"). This test walks every *.bicep
+    file in module-*/ and asserts:
+      - no resource or existing-resource declaration uses a '-preview' suffix
+      - no API version date is from the future (later than today)
+      - each file still compiles under 'az bicep build'
+
+    A sibling regression test guards the specific bleeding-edge versions that were
+    previously in the repo so they do not creep back in.
+
+.EXAMPLE
+    Invoke-Pester -Path .\tests\Api-Version-Policy.Tests.ps1
+
+.NOTES
+    Project: SkyCraft
+#>
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+$RepoRoot    = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$BicepFiles  = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep' |
+               Where-Object { $_.FullName -match '\\module-\d.*\\bicep\\' }
+
+# Allow-list: resource types that have NEVER shipped a stable API version.
+# Microsoft.Insights/diagnosticSettings is permanently stuck on *-preview upstream —
+# see https://learn.microsoft.com/azure/templates/microsoft.insights/diagnosticsettings.
+# Every listed version there is *-preview. Flagging these would be noise, not a real
+# standards violation. The allow-list is passed per-case via -ForEach so it survives
+# Pester 5 discovery/run scope isolation.
+$PreviewAllowList = @(
+    'Microsoft.Insights/diagnosticSettings'
+)
+
+$FileCases = $BicepFiles | ForEach-Object {
+    @{
+        file              = $_.FullName.Substring($RepoRoot.Length + 1)
+        path              = $_.FullName
+        previewAllowList  = $PreviewAllowList
+    }
+}
+
+Describe 'Bicep - no preview API versions' {
+    It "'<file>' declares no '@*-preview' API versions outside the allow-list" -ForEach $FileCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $allow = $previewAllowList
+        $previews = [regex]::Matches($text, "'(Microsoft\.[^/']+/[^@']+)@([0-9-]+-preview)'") |
+                    ForEach-Object { @{ type = $_.Groups[1].Value; api = $_.Groups[2].Value } } |
+                    Where-Object { $allow -notcontains $_.type }
+        $preview_strs = $previews | ForEach-Object { "$($_.type)@$($_.api)" }
+        $preview_strs | Should -BeNullOrEmpty -Because "preview APIs in '$file': $($preview_strs -join ', ')"
+    }
+}
+
+Describe 'Bicep - no future-dated API versions' {
+    BeforeAll { $script:Today = (Get-Date).Date }
+
+    It "'<file>' declares no API versions past today's date" -ForEach $FileCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $dates = [regex]::Matches($text, "'Microsoft\.[^/']+/[^@']+@(\d{4}-\d{2}-\d{2})") |
+                 ForEach-Object { $_.Groups[1].Value } |
+                 Sort-Object -Unique
+        foreach ($d in $dates) {
+            [datetime]::Parse($d) | Should -BeLessOrEqual $script:Today -Because "future-dated API '$d' in '$file' violates bicep-standards.md §2 (Prefer Stable Versions)"
+        }
+    }
+}
+
+Describe 'Bicep - regression guard on known bleeding-edge versions' {
+    It "'<file>' does not reintroduce Microsoft.Web/*@2025-03-01" -ForEach $FileCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $text | Should -Not -Match "Microsoft\.Web/[^@']+@2025-03-01"
+    }
+
+    It "'<file>' does not reintroduce Microsoft.ContainerRegistry/registries@2023-01-01-preview" -ForEach $FileCases {
+        $text = Get-Content -Raw -LiteralPath $path
+        $text | Should -Not -Match "Microsoft\.ContainerRegistry/registries@2023-01-01-preview"
+    }
+}
+
+Describe 'Bicep - module-3.3 and module-3.4 still compile' {
+    $FixedModules = @(
+        @{ file = 'module-3-compute/3.3-containers/bicep/main.bicep'        ; path = (Join-Path $RepoRoot 'module-3-compute/3.3-containers/bicep/main.bicep') }
+        @{ file = 'module-3-compute/3.3-containers/bicep/modules/acr.bicep' ; path = (Join-Path $RepoRoot 'module-3-compute/3.3-containers/bicep/modules/acr.bicep') }
+        @{ file = 'module-3-compute/3.3-containers/bicep/modules/aci.bicep' ; path = (Join-Path $RepoRoot 'module-3-compute/3.3-containers/bicep/modules/aci.bicep') }
+        @{ file = 'module-3-compute/3.3-containers/bicep/modules/containerapps.bicep' ; path = (Join-Path $RepoRoot 'module-3-compute/3.3-containers/bicep/modules/containerapps.bicep') }
+        @{ file = 'module-3-compute/3.4-app-service/bicep/main.bicep'       ; path = (Join-Path $RepoRoot 'module-3-compute/3.4-app-service/bicep/main.bicep') }
+        @{ file = 'module-3-compute/3.4-app-service/bicep/modules/app-service.bicep' ; path = (Join-Path $RepoRoot 'module-3-compute/3.4-app-service/bicep/modules/app-service.bicep') }
+    )
+
+    It "'<file>' compiles via 'az bicep build'" -ForEach $FixedModules {
+        $null = & az bicep build --file $path --stdout 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because "'$file' must compile without errors after API downgrade"
+    }
+}


### PR DESCRIPTION
## Summary

`docs/bicep-standards.md` §2 mandates stable \"Gold Standard\" API versions and warns against bleeding-edge releases. The original audit surfaced two offenders in `module-3-compute`:

- Lab 3.3 containers: `Microsoft.ContainerRegistry/registries@2023-01-01-preview` (three files: `acr.bicep`, `aci.bicep`, `containerapps.bicep`)
- Lab 3.4 app-service: `Microsoft.Web/serverfarms@2025-03-01` and `Microsoft.Web/sites@2025-03-01`

Both replaced with stable releases supported by current Bicep CLI / ARM:

- `Microsoft.ContainerRegistry/registries` → `@2023-07-01`
- `Microsoft.Web/serverfarms` → `@2023-12-01`
- `Microsoft.Web/sites` → `@2023-12-01`

The unrelated `Microsoft.Web/sites/slots@2022-09-01` and `Microsoft.Insights/autoscalesettings@2022-10-01` were already stable and left untouched.

## Why

Bleeding-edge and preview APIs introduce tooling drift and can vanish without notice — every learner gets a different experience.

## Test plan

- [x] `Invoke-Pester -Path tests/Api-Version-Policy.Tests.ps1` → **206/206 pass** across every `*.bicep` in the repo (verified locally 2026-05-26, Pester 5.7.1, PowerShell 7)
- [x] `az bicep build` clean for all six touched files in modules 3.3 and 3.4 (covered by the Pester suite)
- [x] Subscription-scope What-If for lab 3.3 → `status: Succeeded`, no errors (verified 2026-05-26 via `az deployment sub what-if --location swedencentral --template-file module-3-compute/3.3-containers/bicep/main.bicep`)
- [x] Subscription-scope What-If for lab 3.4 → `status: Succeeded`, no errors (verified 2026-05-26 via `az deployment sub what-if --location swedencentral --template-file module-3-compute/3.4-app-service/bicep/main.bicep`)