### PR TITLE
docs(arch): add architecture commentary layer (DESIGN-DECISIONS + per-lab ARCHITECTURE.md)

### DIFF
--- a/DESIGN-DECISIONS.md
+++ b/DESIGN-DECISIONS.md
@@ -1,0 +1,242 @@
+# SkyCraft — Design Decisions & Architecture Layer
+
+> **What this is.** A commentary layer on top of the SkyCraft AZ-104 learning labs.
+> Each lab module has an `ARCHITECTURE.md` that explains **why** a design choice
+> was made, **what the lab simplifies for clarity**, and **how it would differ in
+> a real production environment**. The intent is to help readers signal
+> architect-level judgment, not to convert SkyCraft into a hardened reference
+> architecture.
+>
+> **What this is not.** A production reference architecture. SkyCraft labs are
+> deliberately simplified for learning: encryption is often optional, networks
+> are flat where flat is clearer, costs are minimized over redundancy, and
+> several governance/security controls are deferred or made opt-in. The
+> `ARCHITECTURE.md` files name those simplifications explicitly so a reader can
+> see the gap between a lab and production.
+
+---
+
+## Per-module architecture notes
+
+| Module | Lab | Architecture notes |
+|---|---|---|
+| 1 — Identities & Governance | 1.1 Entra Users & Groups | [ARCHITECTURE.md](module-1-identities-governance/1.1-entra-users-groups/ARCHITECTURE.md) |
+| 1 — Identities & Governance | 1.2 RBAC | [ARCHITECTURE.md](module-1-identities-governance/1.2-rbac/ARCHITECTURE.md) |
+| 1 — Identities & Governance | 1.3 Governance | [ARCHITECTURE.md](module-1-identities-governance/1.3-governance/ARCHITECTURE.md) |
+| 2 — Networking | 2.1 Virtual Networks | [ARCHITECTURE.md](module-2-networking/2.1-virtual-networks/ARCHITECTURE.md) |
+| 2 — Networking | 2.2 Secure Access | [ARCHITECTURE.md](module-2-networking/2.2-secure-access/ARCHITECTURE.md) |
+| 2 — Networking | 2.3 Name Resolution | [ARCHITECTURE.md](module-2-networking/2.3-name-resolution/ARCHITECTURE.md) |
+| 3 — Compute | 3.1 Infrastructure as Code | [ARCHITECTURE.md](module-3-compute/3.1-infrastructure-as-code/ARCHITECTURE.md) |
+| 3 — Compute | 3.2 Virtual Machines | [ARCHITECTURE.md](module-3-compute/3.2-virtual-machines/ARCHITECTURE.md) |
+| 3 — Compute | 3.3 Containers | [ARCHITECTURE.md](module-3-compute/3.3-containers/ARCHITECTURE.md) |
+| 3 — Compute | 3.4 App Service | [ARCHITECTURE.md](module-3-compute/3.4-app-service/ARCHITECTURE.md) |
+| 4 — Storage | 4.1 Storage Accounts | [ARCHITECTURE.md](module-4-storage/4.1-storage-accounts/ARCHITECTURE.md) |
+| 4 — Storage | 4.2 Blob Storage | [ARCHITECTURE.md](module-4-storage/4.2-blob-storage/ARCHITECTURE.md) |
+| 4 — Storage | 4.3 Azure Files | [ARCHITECTURE.md](module-4-storage/4.3-azure-files/ARCHITECTURE.md) |
+| 4 — Storage | 4.4 Storage Security | [ARCHITECTURE.md](module-4-storage/4.4-storage-security/ARCHITECTURE.md) |
+| 5 — Monitoring & Maintenance | 5.1 Azure Monitor | [ARCHITECTURE.md](module-5-monitoring-maintenance/5.1-azure-monitor/ARCHITECTURE.md) |
+| 5 — Monitoring & Maintenance | 5.2 Business Continuity | [ARCHITECTURE.md](module-5-monitoring-maintenance/5.2-business-continuity/ARCHITECTURE.md) |
+| 5 — Monitoring & Maintenance | 5.3 Network Monitoring | [ARCHITECTURE.md](module-5-monitoring-maintenance/5.3-network-monitoring/ARCHITECTURE.md) |
+
+---
+
+## Cross-cutting design themes
+
+These are the load-bearing architectural decisions that show up in more than
+one module. The per-module notes explain how each theme materializes in that
+lab; this section is the architect's view in one place.
+
+### 1. Hub-Spoke network topology
+
+- **Lab:** One Platform (Hub) VNet `10.0.0.0/16` + two spokes — Development
+  `10.1.0.0/16`, Production `10.2.0.0/16`. Hub ↔ spoke peering only; **no
+  spoke-to-spoke peering**, so spokes can only reach each other transitively
+  through the hub.
+- **Production gap:** No central inspection (Azure Firewall / NVA), no NAT
+  Gateway for controlled egress, no ExpressRoute or VPN gateway. The
+  `GatewaySubnet` is reserved but unused. A real hub holds central DNS
+  forwarders, firewall, and shared egress.
+- **Why it matters:** The topology is correct for production; what is missing
+  is the *machinery inside the hub* that justifies the topology.
+
+### 2. Region lock — Sweden Central
+
+- **Lab:** All deployments default to `swedencentral`. Allowed values in
+  parameter validators are typically `swedencentral`, `westeurope`,
+  `northeurope`.
+- **Production gap:** No multi-region deployment, no paired-region failover,
+  no Traffic Manager / Front Door geographic routing. Storage GRS gives passive
+  geo-redundancy of bytes only, not of compute.
+- **Why it matters:** A single-region project has implicit RPO/RTO
+  characteristics that should be made explicit (and accepted) in any real
+  design review.
+
+### 3. Resource naming convention
+
+- **Lab:** `{environment}-{project}-{region-code}-{resource-type-suffix}`
+  enforced uniformly. Examples: `prod-skycraft-swc-vnet`,
+  `dev-skycraft-swc-rg`, `plat-skycraft-swc-nsg-auth`. Codified in
+  [docs/bicep-standards.md](docs/bicep-standards.md).
+- **Production gap:** No automated linter / policy enforcement of the naming
+  scheme; deviations rely on PR review.
+- **Why it matters:** Naming is the first FinOps signal. A consistent prefix is
+  the difference between a clean cost report and a forensic investigation.
+
+### 4. Mandatory tag taxonomy
+
+- **Lab:** Every resource carries `Project`, `Environment`
+  (`Platform` / `Development` / `Production`), `CostCenter`
+  (`MSDN` / `Student-Funded`), `Owner`. Defined in
+  [SPECIFICATION.md](SPECIFICATION.md) and [docs/bicep-standards.md](docs/bicep-standards.md).
+- **Production gap:** Tags are *applied* in Bicep but only a subset
+  (`Project`, `Environment`) is *enforced* by Azure Policy in Lab 1.3.
+  `CostCenter` and `Owner` can drift silently if a resource is created outside
+  IaC.
+- **Why it matters:** Tag-driven cost allocation only works if every resource
+  is tagged. One untagged storage account becomes the line in the budget
+  alert that nobody can explain.
+
+### 5. Personas → RBAC mapping
+
+- **Lab:** Four Warcraft personas — Malfurion (Owner), Khadgar (Contributor),
+  Chromie (Reader), Illidan (Guest). Mapped to three security groups
+  (Admins, Developers, Testers) and assigned via Lab 1.2.
+- **Production gap:** No Privileged Identity Management (PIM) for time-bound
+  Owner/Contributor activation; no Conditional Access policies; no
+  entitlement reviews for guests; no Deny assignments to protect critical
+  resources.
+- **Why it matters:** Permanent Owner on a subscription is a pen-test gift.
+  The lab teaches the *what*; production needs the *when* (PIM) and the
+  *unless* (Deny).
+
+### 6. Environment stratification (Platform / Dev / Prod)
+
+- **Lab:**
+  - **Platform / Hub:** shared services, GRS storage, optional Bastion.
+  - **Development:** LRS storage, public-blob containers permitted for demos,
+    no locks, no enforced policies.
+  - **Production:** GRS storage, fully-private blob containers, `CanNotDelete`
+    locks (Lab 1.3), lifecycle policies (Lab 4.2), backups (Lab 5.2).
+- **Production gap:** No staging / pre-prod between Dev and Prod; no separate
+  subscription per environment (a real enterprise pattern); no test data
+  isolation.
+- **Why it matters:** Two-tier (Dev + Prod) is the floor, not the ceiling. The
+  lab makes the trade-off explicit; a real engagement should evaluate it.
+
+### 7. Redundancy by layer
+
+- **Lab:**
+  - **Compute:** Two VMs across **different availability zones** (Auth in AZ1,
+    World in AZ2). No VM scale sets, no cross-region replication.
+  - **Storage:** **GRS** for Platform/Prod, **LRS** for Dev (Lab 4.1).
+  - **Networking:** Standard SKU Public IPs and Load Balancers (both
+    zone-aware), but a single LB instance per environment.
+- **Production gap:** No automated failover, no zone-redundant gateways, no
+  active-active multi-region. Backup vault is LRS in Lab 5.2.
+- **Why it matters:** AZs protect against a single datacenter; they do not
+  protect against a regional outage. The lab teaches the cheap half of the
+  picture.
+
+### 8. Public IP & Load Balancer SKU — always Standard
+
+- **Lab:** All Public IPs and Load Balancers are **Standard SKU** (Basic is
+  deprecated). Standard PIPs are zone-aware and required by Standard LB.
+- **Production gap:** No DDoS Standard plan, no Azure Front Door / Application
+  Gateway in front of the LB, no WAF.
+- **Why it matters:** Standard SKU is the floor for any modern Azure
+  deployment; everything above it (DDoS, WAF, CDN) is layered on top.
+
+### 9. Defense-in-depth — NSGs, ASGs, Bastion
+
+- **Lab:** NSG per subnet (not flat), ASGs defined per workload tier
+  (Auth / World / DB), Bastion **optional** (`parDeployBastion=false` default
+  to save ~€140/mo). Game ports (3724, 8085) and DB port (3306) restricted to
+  caller subnets.
+- **Production gap:** No Azure Firewall, no egress restrictions (only ingress
+  is constrained), NSG flow logs not enabled until Lab 5.3, no Defender for
+  Cloud, no Just-in-Time VM access.
+- **Why it matters:** NSGs are stateless and L3/L4 only. They are the
+  perimeter, not the strategy.
+
+### 10. Encryption — optional and lab-friendly
+
+- **Lab:** VM disk encryption is *opt-in* (`None` / `EncryptionAtHost` /
+  `AzureDiskEncryption`, Lab 3.2). Storage infrastructure encryption is a
+  creation-only flag, default off. Customer-managed keys never used.
+- **Production gap:** No CMK in Key Vault, no key rotation policies, no Double
+  Encryption mandated for regulated workloads.
+- **Why it matters:** Encryption-at-rest is on by default with
+  Microsoft-managed keys; the lab teaches that the *interesting* decisions
+  (CMK, infrastructure encryption, host encryption) sit above that baseline.
+
+### 11. Cost controls — burstable, optional, deletable
+
+- **Lab:** B-series burstable VMs by default. Bastion default-off. LRS for Dev
+  storage. App Service P0V4 used in Lab 3.4 *deliberately* to teach Premium
+  features, but its cost is called out explicitly.
+- **Production gap:** No Azure Reservations, no Savings Plans, no Spot VMs, no
+  budget alerts deployed by Bicep (Lab 1.3 mentions them but defers to portal).
+- **Why it matters:** Lab-grade cost discipline is "delete when done."
+  Production-grade cost discipline is reservations + budgets + anomaly
+  detection. The lab does the first half well.
+
+### 12. Data protection — soft delete & lifecycle
+
+- **Lab:** Blob soft delete = 7 days everywhere (Lab 4.1). Production
+  containers carry a lifecycle policy that ages logs through Cool (30d) → Cold
+  (90d) → Archive (180d) → Delete (365d). Backups are archived after 7 days
+  (Lab 4.2).
+- **Production gap:** No immutable / WORM containers, no legal hold, no
+  cross-region snapshot copies for critical data, soft-delete window is short
+  for serious compliance.
+- **Why it matters:** Lifecycle is a cost lever **and** a retention lever.
+  The lab shows both correctly; what's missing is the *immutability* lever for
+  audit/regulatory data.
+
+### 13. Centralized monitoring
+
+- **Lab:** A single Log Analytics Workspace lives in the Platform RG (Lab
+  5.1). VM Insights via DCR. Metric alerts route through one Action Group
+  (email only). VNet Flow Logs v2 with Traffic Analytics (Lab 5.3) send to the
+  same workspace. Diagnostic settings on storage forward audit logs there too.
+- **Production gap:** No Defender for Cloud, no Microsoft Sentinel, no SMS /
+  PagerDuty / Teams escalation paths, retention is 30 days only, workspace is
+  in a single region with no replication.
+- **Why it matters:** Centralization is the right architecture decision; the
+  lab gets that part right. What it omits is the *escalation* and
+  *retention* posture that an SRE / SecOps team needs in practice.
+
+### 14. Infrastructure-as-Code maturity
+
+- **Lab:** Bicep throughout (no ARM JSON). `main.bicep` orchestrator pattern
+  with reusable modules in `bicep/modules/`. Standardized header block
+  (SUMMARY / DESCRIPTION / EXAMPLE / AUTHOR / VERSION). API versions pinned
+  (`2023-11-01` for Networking, `2022-04-01` for Authorization). PowerShell
+  conventions and Bicep conventions enforced via
+  [docs/bicep-standards.md](docs/bicep-standards.md) and
+  [docs/powershell-standards.md](docs/powershell-standards.md).
+- **Production gap:** No CI/CD pipeline that lints / validates / `what-if`s
+  the Bicep before deployment. No drift detection. No `Microsoft.Resources/deploymentStacks`
+  for managed deletion.
+- **Why it matters:** Templates without a pipeline are still
+  click-through-with-extra-steps. The lab demonstrates the artifact;
+  production needs the workflow.
+
+---
+
+## Author TODOs
+
+Several `ARCHITECTURE.md` files contain `TODO(author):` markers where rationale
+could not be inferred from code alone and should be confirmed by the project
+author. They cluster around:
+
+- Specific game-port choices (3724, 8085) — assumed WoW-compatible defaults
+  but not documented.
+- Egress NSG strategy — currently allow-all by default; production would
+  constrain.
+- ACR credential handling in Lab 3.3 — registry password leaks through Bicep
+  outputs.
+- Public DNS zone — `skycraft.example.com` is a placeholder and a
+  "bring-your-own-domain" variant has not been written.
+
+A consolidated list is in the PR description that introduces this layer.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ Transform abstract cloud concepts into **tangible hands-on experience** by build
 
 ---
 
+## 🏛️ Architecture Layer
+
+Alongside the step-by-step labs, the repository carries an **architecture
+commentary layer** that explains *why* each lab is built the way it is, what
+the lab deliberately simplifies for clarity, and how a real production
+deployment would differ.
+
+- See [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) for the cross-cutting view
+  and the index linking to every per-module `ARCHITECTURE.md`.
+- Each lab's `ARCHITECTURE.md` (e.g. `module-2-networking/2.1-virtual-networks/ARCHITECTURE.md`)
+  covers design decisions & trade-offs, lab-vs-production gaps, a light
+  Well-Architected lens, and a cost / FinOps note.
+
+This layer is **additive learning context**, not a production reference
+architecture. SkyCraft remains a hands-on AZ-104 learning project; the
+architecture notes are there to make the trade-offs explicit so the same code
+can also be read as an architect-level case study.
+
+---
+
 ## 🛠️ Technology Stack
 
 | Category               | Tool                       | Purpose                   |

--- a/module-1-identities-governance/1.1-entra-users-groups/ARCHITECTURE.md
+++ b/module-1-identities-governance/1.1-entra-users-groups/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Architecture Notes: Lab 1.1 — Entra Users and Groups
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| User principal naming | `firstname.lastname@[tenant].onmicrosoft.com` (Warcraft personas: Malfurion, Khadgar, Chromie, Illidan) | UPN formats (smith.john@company.com, jsmith@example.com) | Warcraft personas create memorable teaching personas tied to roles (Owner, Contributor, Reader, Guest per SPECIFICATION.md §3.2). Simplifies storytelling and role mapping. |
+| Group membership strategy | Direct member assignment (Assigned type); one-to-one persona→group mapping | Dynamic group rules (e.g., based on department attributes); nested groups | Static assignment is transparent and predictable for a lab. Production would use dynamic membership rules to reduce manual maintenance. |
+| Guest user model | B2B invite model (`Invite external user`) sent to `istormrage@illidari.com` | Guest account already in tenant; federated identity | B2B invitation teaches external partner workflows; real scenarios often involve cross-tenant federated access. |
+| MFA/Conditional Access scope | Portal shows conditional access options; lab mentions "delegated administration" but does not require MFA setup | Enforce MFA on all users; conditional access policies requiring MFA for risky logins | Lab focuses on user/group structure basics; MFA policies are typically org-wide settings configured separately. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| User lifecycle | Manual creation in portal (via wizard) | Automated provisioning via Entra Connect, Okta, or Workday sync; bulk import via PowerShell | Reduces toil; syncs on-premises AD or HR systems. |
+| Group membership dynamics | Assigned (manual) membership; one user per group | Dynamic groups (e.g., "all employees in Finance"), nested groups (e.g., Admin group contains Department-Admin subgroups) | Scaling to hundreds/thousands of users requires automation; nested groups model org hierarchy. |
+| License assignment | Manual assignment per user (mentioned in objectives) | Group-based licensing; conditional license provisioning | Group-based licensing avoids manual churn when users move roles. |
+| Guest access governance | Simple invitation with custom message | Conditional access policies, entitlement reviews, time-limited access, B2B direct connect | Guests represent external risk; production limits their scope and requires periodic access reviews. |
+| Auditing & logging | Lab does not explicitly configure audit logging | Enable Entra ID audit logs, configure Azure AD Sign-in logs, export to SIEM | Forensic trace of who accessed what and when; regulatory requirement in most enterprises. |

--- a/module-1-identities-governance/1.2-rbac/ARCHITECTURE.md
+++ b/module-1-identities-governance/1.2-rbac/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture Notes: Lab 1.2 — RBAC
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Role assignment scope | Mixed: subscription scope (Owner on admin user), resource group scope (Contributor on DevRG, Reader on TestRG) | All at subscription scope; all at RG scope | Mixed scopes teach the principle of least privilege: admin gets subscription-wide Owner; developers get only RG-level Contributor. Reflects real-world job boundaries. |
+| Built-in vs. custom roles | Owner, Contributor, Reader (built-in, lines 41–43 in `role-assignments.bicep`) | Custom role (e.g., "VM Operator" with only VM mgmt permissions) | Built-in roles are discoverable and well-documented. Custom roles are needed later when granularity exceeds built-in coverage; keeping to built-in simplifies the lab. |
+| Group-based vs. principal-based assignment | Groups assigned to RGs (SkyCraft-Developers → Contributor on dev RG; SkyCraft-Testers → Reader on both dev and prod RGs) | Individual user assignments; service principal assignments | Group-based simplifies role management: adding/removing users from a group updates all associated role assignments without modifying RBAC directly. |
+| Idempotency via `guid()` | Role assignment name computed with `guid(resourceGroup().id, parPrincipalId, parRoleDefinitionId)` (line 23 in `rg-role-assignment.bicep`) | Sequential naming (role-assignment-1, role-assignment-2); random GUIDs | `guid()` ensures the same assignment request re-applies idempotently (Bicep upserts the same resource). Prevents accidental duplicates on re-deployment. |
+| API version for role assignments | `Microsoft.Authorization/roleAssignments@2022-04-01` (line 22 in `rg-role-assignment.bicep`) | @2021-10-01 or earlier | 2022-04-01 is stable and widely used; includes principalType parameter (User/Group/ServicePrincipal) for validation. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Principal IDs as parameters | Bicep expects pre-computed principal IDs (parAdminPrincipalId, parDeveloperGroupPrincipalId, etc.) passed from a script | Lookup of users/groups by name within Bicep; integration with Entra ID API; service principals registered in the tenant | Manual principal ID collection is error-prone; production tools (Terraform, AzureRM PowerShell) resolve principal names automatically. |
+| Scope hierarchy | Three RGs (dev, prod, platform); admin at subscription, developers at dev RG, testers at dev + prod RGs | Management groups layered above subscription (e.g., tenant-wide policies); cross-subscription delegated access; conditional access policies | Management groups allow policy inheritance across multiple subscriptions; realistic for large enterprises. |
+| Role audit trail | Portal shows role assignments; lab does not configure continuous audit logging | Enable Azure AD audit logs; stream to Log Analytics; query via KQL for compliance reporting | Tracks who made access changes and when; critical for SOC 2 / ISO 27001. |
+| Time-bound access | All assignments are permanent | Privileged Identity Management (PIM) for time-limited role activation; conditional access for time-based access gates | Lab user has permanent Contributor; production elevates to Contributor only during maintenance windows. |
+| Deny assignments | Not used in this lab | Deny assignments to explicitly block an action (e.g., deny subscription-wide deletion) even if a role grants it | Deny supplements Allow; lab keeps it simple with Allow-only. Real-world risk mitigation often uses Deny (e.g., prevent production resource deletion even from Owner role). |

--- a/module-1-identities-governance/1.3-governance/ARCHITECTURE.md
+++ b/module-1-identities-governance/1.3-governance/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# Architecture Notes: Lab 1.3 — Governance
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Tag taxonomy | Four keys (Environment, Project, CostCenter, Owner) applied at RG scope via `modules/tags.bicep` (lines 57–79 in main.bicep); values defined in varTagsDev, varTagsProd, varTagsPlatform | Minimal tagging (only Environment); extensive taxonomy (20+ keys covering app, team, cost driver, data classification) | Four keys balance clarity and manageability. Lab demonstrates tag inheritance via Bicep; production would enforce via policy. |
+| Lock level | `CanNotDelete` on prod and platform RGs (line 17 in `modules/locks.bicep`) | `ReadOnly` (prevents any modification); no locks on dev RG | `CanNotDelete` prevents accidental RG deletion but allows resource updates. Dev RG left unlocked for experimentation. `ReadOnly` is stricter but breaks legitimate updates (e.g., scaling a VM). |
+| Policy assignments at subscription scope | Three policy assignments (lines 24–87 in `modules/policies.bicep`): Require Environment tag on RGs, Enforce Project=SkyCraft tag on resources, Restrict to allowed locations (swedencentral, northeurope) | Management group scope (applies across subscriptions); custom policy definitions; audit-only vs deny effect | Subscription scope is appropriate for a single-tenant learning project. Policy definitions (96670d01-0a4d-4649-9c89-2d3abc0a5025, etc.) are built-in Microsoft definitions; custom policies add maintenance burden. Audit-only would allow non-compliant resources (defeats governance goal); Deny blocks creation, teaching hard constraints. |
+| Policy effect mode | Deny (implicit, via "Require" and "Enforce" built-in policy definitions) | Audit (log violations but allow creation); DeployIfNotExists (auto-remediate by adding missing tags) | Deny educates users immediately about policy; Audit would allow students to bypass. DeployIfNotExists is safer for auto-remediation but adds complexity. |
+| Geographic scope | Two allowed locations: Sweden Central (primary) and North Europe (failover region, line 86–87 in main.bicep) | Single region (swedencentral only); EU-wide (all European regions) | Two regions teach geo-redundancy; single region keeps the lab simple. Restricting to EU demonstrates data residency governance (relevant for GDPR labs in later modules). |
+| Module scoping | Tags applied per RG via separate module calls (modTagsDev, modTagsProd, modTagsPlatform); locks applied per RG; policies applied at subscription scope once | Single module applying tags/locks/policies to all RGs; centralized policy assignment in separate stack | Per-RG modularity teaches that tags and locks are RG-scoped, while policies are subscription-scoped. Separate calls make the targeting explicit. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Tag compliance enforcement | Azure Policy enforces two tag presence rules (Environment, Project); other tags (CostCenter, Owner) are applied but not enforced by policy | Comprehensive tag compliance: all four mandatory tags enforced by policy with denial; cost allocation tags mapped to billing export | Lab demonstrates policy basics; production must enforce all compliance tags to prevent billing misallocation and cost center disputes. |
+| Lock granularity | Locks at resource group scope (entire RG protected by CanNotDelete) | Locks at individual resource scope (e.g., lock only the production SQL database, allow RG operations); combination of CanNotDelete and ReadOnly per resource type | Lab simplicity: one lock per RG. Production protects critical resources only, allowing other resources to be updated/deleted (reduces accidental blocks). |
+| Policy scope and nested governance | Policies assigned at subscription scope; applies uniformly to all RGs | Policy assignments at management group scope for multi-subscription rollout; policy exceptions via exemptions; tiered policies (strict on prod, audit-only on dev) | Single subscription lab has no scope advantage. Enterprise with 50+ subscriptions centralizes governance at management group. Exemptions allow controlled "break glass" for temporary overrides. |
+| Custom policies & initiatives | Lab uses three built-in policy definitions; no custom policies | Custom policy definitions (e.g., "VM must be in an availability set"); policy initiatives grouping related policies (e.g., "Security Baseline" = 10 policies bundled) | Built-in policies are discoverable and battle-tested. Custom policies are useful for org-specific rules (e.g., "all databases must have customer-managed keys"). Lab keeps it foundational. |
+| Cost controls & budgets | Lab title mentions budgets and Azure Advisor (objectives), but Bicep does not deploy them; lab guide Section 4 covers manual budget creation in portal | Bicep deployment of budget alerts; cost anomaly detection; reserved instances; rightsizing recommendations from Advisor | Lab defers cost controls to manual setup (portal only). Production automates budget thresholds and connects to alerts/webhooks for immediate escalation. |
+| Audit logging & reporting | Lab does not explicitly configure Activity Log export or diagnostic settings | Send Activity Log to Log Analytics workspace; query via KQL (e.g., "show all policy violations in the last 7 days"); set up alerts for policy assignment changes | Governance must be auditable; lab focuses on enforcement mechanism, not audit trail. |
+| Deny assignment or policy exceptions | No deny assignments; no policy exemption mechanism configured | Deny assignments for explicit "no" (e.g., block delete on sensitive resources even for Owner); policy exemptions for time-limited overrides (e.g., "allow non-compliant VM during incident response") | Lab keeps deny/exemptions out of scope. Real governance uses both to balance security with operational agility. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar**: Operational Excellence and Governance. Lab establishes naming conventions, tagging for cost tracking, policy enforcement, and resource protection.
+- **Security tension**: Locks prevent accidental deletion but also block legitimate updates; balancing is a design trade-off (CanNotDelete vs ReadOnly).
+- **Cost alignment**: Tags enable cost allocation by environment and cost center; policies restrict deployment to approved (cheaper) regions.
+- **Compliance**: Policy assignments enforce tag presence and geographic boundaries, supporting future audit and regulatory requirements.
+
+## 4. Cost / FinOps note
+
+**Monthly cost of running Lab 1.3 resources**:
+- Azure Policy: **Free** (built-in policies incur no compute charge; assignment at subscription scope is no-cost).
+- Resource Locks: **Free** (management locks are a metadata feature; no per-lock fee).
+- Tags: **Free** (name-value pairs stored as resource metadata).
+- **Total governance overhead**: EUR 0.00/month.
+
+**Cost control strategy**:
+- This lab enforces **allowed locations** (swedencentral + northeurope). Enforcement prevents accidental deployment to premium regions (e.g., West US 2).
+- The **policy restriction** ensures all SkyCraft resources land in cost-optimized European regions.
+- No auto-shutdown or time-based scaling is configured; lab resources are expected to be cleaned up after the lab ends.
+
+**Cleanup reminder** (post-lab):
+- **Subscription-level artifacts**: Policy assignments (three assignments created by `modules/policies.bicep`) persist at subscription scope and should be deleted via Azure Portal → Policy → Assignments → select each SkyCraft policy → Delete.
+- **RG-level artifacts**: Locks and tags are scoped to RGs (dev-skycraft-swc-rg, prod-skycraft-swc-rg, platform-skycraft-swc-rg) and are deleted automatically when RGs are deleted.
+- **To fully clean up**: Delete the three resource groups (RGs are NOT automatically deleted); this will cascade-delete all locks, tags, and policy data within those RGs. Then delete the three subscription-scoped policy assignments.
+- **Cost risk if not cleaned up**: Zero (governance constructs are free), but policy assignments may interfere with other projects if left assigned.

--- a/module-2-networking/2.1-virtual-networks/ARCHITECTURE.md
+++ b/module-2-networking/2.1-virtual-networks/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Architecture Notes: Lab 2.1 — Virtual Networks
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| **Hub-Spoke topology** | Three VNets: 1 hub + 2 spokes; spoke-to-spoke *not* directly peered | Flat single VNet; full mesh peering; hub-and-branch (multiple hubs) | Hub-spoke scales well, teaches centralized routing model, and prevents accidental spoke-to-spoke shortcuts. No spoke-to-spoke peering forces traffic through hub, demonstrating how real enterprises control north-south traffic flows. |
+| **Address space sizing** | Generous `/16` per VNet (65,536 IPs each) with `/24` subnets (256 IPs) | Tightly-sized `/27` (32 IPs) or `/28` subnets; classless allocation | Generous spacing keeps the lab simple and readable; real production sizing requires careful capacity planning and reserves growth headroom per RFC 1918 strategy. This teaches the principle: always over-allocate in labs to avoid re-addressing. |
+| **Subnet granularity** | Hub: 2 subnets (Bastion + Gateway); Spokes: 4 subnets each (Auth, World, DB, AppService) | Single flat subnet per VNet | Subnet segmentation enables NSG rules per workload tier and teaches Azure's fundamental isolation pattern. Demonstrates that subnets are *free*—use them liberally. |
+| **Public IP (Standard SKU)** | Static Public IP (Standard) for future Load Balancers | Basic SKU (deprecated); Elastic IP analogue | Standard SKU is required for Standard LB (Lab 2.3) and enforces availability zone redundancy awareness. Also teaches that Standard PIP billing (~€3.40/mo) is negligible vs. security benefit. |
+| **Peering configuration** | Bidirectional peering (hub←→dev, hub←→prod); both directions allow *forwarded traffic* | Unidirectional peering; gateway transit disabled | Bidirectional peering with forwarded traffic allows hub to become future firewall/routing hub. `allowForwardedTraffic: true` (lab-guide-2.1.md, lines 42–43) shows the intent: central inspection is the *future state*. Gateway transit disabled because no ExpressRoute/VPN is deployed yet. |
+| **Region selection** | Sweden Central (swedencentral) | West Europe, East US, other regions | Sweden Central is arbitrary but consistent across all labs (CLAUDE.local.md, SPECIFICATION.md). In production, region depends on data residency, latency to users, and feature availability. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| **Network segmentation** | Three static VNets (Platform, Dev, Prod) with fixed CIDR ranges | Dynamic VNet creation, overlapping CIDR ranges via NAT, multi-region replication, private endpoints for all PaaS, Azure Firewall in hub | Production must handle growth: new regions, new business units, overlapping CIDR (via forced tunneling). The lab's fixed sizing teaches the principle: IP space is a precious, finite resource. |
+| **Peering scope** | Manual peering between named VNets | Automated peering via policies (Azure Policy or Terraform modules), transitive peering via hub firewall rules, automatic route propagation | Manual peering in the lab is transparent for learning. Production automates this with Infrastructure-as-Code (IaC) to avoid human error and enable GitOps compliance. |
+| **DNS resolution** | Azure-provided default (168.63.169.254) | Custom Private DNS Zones (Lab 2.3) + VNet links, private resolvers for hybrid DNS, conditional forwarding to on-premises | Azure's default DNS works for internal Azure resources but lacks flexibility. Lab 2.3 introduces Private DNS. Production adds resolvers for hybrid scenarios. |
+| **Gateway subnet** | Reserved (10.0.1.0/27) but unused in this lab | ExpressRoute Gateway or VPN Gateway deployed here in future labs | Gateway subnet is *reserved* per Azure design best practice, even if not used immediately. This teaches planning: always leave room for connectivity later. |
+| **Monitoring / logging** | Not included in this lab | Network Watcher, NSG flow logs, VNet peering metrics, Packet Capture, Diagnostics | The lab is observability-free. Production requires observability to detect link flaps, asymmetric routes, and DDoS attacks. Covered in Module 5. |
+| **Cost optimization** | Resources left running continuously | Auto-shutdown, dev/test subscriptions for spare environments, resource groups for cost allocation, budget alerts | Lab resources incur ~€2–4/mo (3 VNets + 2 PIPs, peering is free). Production maps cost to business units and enforces cleanup. |
+
+## 3. Well-Architected lens (light)
+
+**Dominant pillars:**
+- **Operational Excellence**: The hub-spoke topology centralizes administration (single Bastion, single firewall location).
+- **Security**: Subnet segmentation and peering isolation reduce blast radius of a compromised spoke.
+
+**Key trade-off:** Clarity vs. complexity. The lab sacrifices auto-failover and redundancy (single gateway per region) for simplicity.
+
+- **Reliability**: Hub-spoke is resilient *within* a region (no SPOF if Bastion/gateway are HA-deployed); no multi-region failover.
+- **Performance Efficiency**: Three `/16` VNets incur peering latency (~1–5 ms within region); acceptable for learning but monitored in production (Network Watcher).
+- **Cost Optimization**: Peering is free. VNets themselves are free. The only cost: Public IPs (~€3.40/mo each, only 2 in Lab 2.1) and data transferred out of Azure.
+
+## 4. Cost / FinOps note
+
+**Monthly cost (if left running):**
+- 3 VNets: €0 (free resource)
+- 2 Standard Public IPs: 2 × €3.40 = €6.80
+- VNet peering (4 links): €0 (free)
+- **Total: ~€6.80 / month**
+
+**Lab cost controls:**
+- Turn off VMs when not in use (Module 3).
+- Delete unused Public IPs immediately; they are billed even when disassociated from resources.
+- Peering has no inactivity penalty.
+
+**Cleanup reminders after lab:**
+1. Delete Public IPs if not using Load Balancer (Lab 2.3).
+2. Leave VNets in place—Labs 2.2 and 2.3 depend on them.
+3. Monitor for orphaned resources: check for unattached NICs (created during VM teardown, cost ~€1–2 if left dangling).

--- a/module-2-networking/2.2-secure-access/ARCHITECTURE.md
+++ b/module-2-networking/2.2-secure-access/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# Architecture Notes: Lab 2.2 — Secure Access
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| **NSG placement** | One NSG per subnet (Auth, World, DB) per spoke; Hub NSG is empty at start | One NSG per VNet; NSGs on NICs only; centralized Azure Firewall | Per-subnet NSGs teach the fundamental pattern: firewall rules are *closest* to the protected resource. Empty hub NSG is intentional—it demonstrates that NSGs are allow-lists (default-deny). |
+| **ASG usage** | Define ASGs for Auth/World/DB tiers; *reserve* for future NIC membership | Skip ASGs; inline CIDR rules only | ASGs are "security groups" for logical grouping (like AWS Security Groups). Defining them now teaches the pattern: group *roles*, not IPs. In a real network, an Auth server can be added to the Auth ASG without touching rules. |
+| **Bastion deployment** | Optional (parDeployBastion = false by default) | Mandatory deployment; separate lab | Bastion adds ~€140/mo, so making it optional teaches cost discipline. Optional deployment is a realistic trade-off: some labs skip it to save budget. Default off avoids surprising learners with a big bill. |
+| **Bastion SKU** | Basic SKU (cheaper, no native RDP/SSH file transfer) | Standard SKU (more features, higher cost); no Bastion | Basic SKU is sufficient for lab: students learn the core concept (eliminate public IPs). Real production might upgrade to Standard for auditing. Cost difference: ~€60/mo, worth teaching. |
+| **NSG rule specificity** | Bastion subnet hardcoded as 10.0.0.0/26 in spoke rules; explicit port numbers (22, 3724, 8085) | Wildcards (*) for source/dest; dynamic parameter lookups | Hardcoding Bastion subnet teaches best practice: minimize blast radius by being *explicit*. Explicit ports (SSH:22, Auth:3724, World:8085) document the game architecture. TODO(author): Why these specific game ports? (Likely WoW-compatible defaults; confirm with game server docs.) |
+| **Database security** | MySQLPort 3306 only from Auth + World subnets (not from internet) | Allow from anywhere; firewalls in DB layer only | Layered security: NSG is *first* gate. A DB exposed to internet-inbound is a common breach. This rule teaches: databases are never public-facing. |
+| **Service endpoints** | Enabled on DB subnet for Microsoft.Sql and Microsoft.Storage | No service endpoints; rely on private endpoints (Lab 2.2, line 244–256) | Service endpoints allow subnet-level access to PaaS without public IP. Cheaper than private endpoints (~€0 vs. ~€7.50/mo) but less isolated. Lab teaches both: endpoints are a good starting point. |
+| **Outbound rules** | Not configured (default: allow all outbound) | Explicit allow-lists for egress | Lab skips egress rules for simplicity. Production uses egress NSGs to prevent data exfiltration. This is a major lab simplification. TODO(author): Add egress examples to advanced challenge section? |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| **Bastion access control** | Single Bastion shared by all users | Conditional Access (Entra ID), Just-in-Time (JIT) access, per-user approval workflows, audit logs shipped to SIEM | Lab Bastion is wide-open once deployed. Real production must enforce *least privilege*: only authorized admins get sessions, and only for short time windows. |
+| **Network policy enforcement** | Manual NSG rules per subnet | Azure Policy (built-in: "Deny all inbound, allow explicit") to prevent misconfiguration, automated remediation | Production is *policy-driven*: teams can't create an NSG without explicit inbound rules (or policy fails). Lab is *rule-driven*: humans write rules. |
+| **Logging and monitoring** | NSG rules exist but no flow logs | NSG Flow Logs → Storage → Network Watcher for forensics, traffic analytics, anomaly detection, integration with Sentinel (SIEM) | Lab has no observability. In production, every denied packet is logged for auditing and incident response. |
+| **Encryption in transit** | Game ports (3724, 8085) assumed encrypted by application | TLS/mTLS for all east-west traffic, Azure Private Link (redundant encryption layer) | Lab assumes app-level encryption. Production enforces transport encryption at the network layer. |
+| **High availability** | Single Bastion (single AZ) | Redundant Bastions across zones, or alternative access (Private Endpoints to management services) | Single Bastion is a SPOF. Production spreads VMs across availability zones; Bastion should too. |
+| **Blast radius** | NSG misconfiguration blocks a subnet for minutes; manual fix | Automated NSG rollback via Azure Policy or Bicep immutability, canary deployments (roll out rules to 10% of traffic first) | Lab is manual. Production must have fast recovery and validation gates. |
+| **ASG utilization** | ASGs defined but not used (NICs not added until Module 3) | NICs added to ASGs immediately; rules reference ASGs not CIDRs; scale-out adds NICs to ASG, rules auto-apply | Lab preps ASGs; real usage is in Module 3. Production assigns every NIC to an ASG, so rules are dynamic and self-service. |
+
+## 3. Well-Architected lens (light)
+
+**Dominant pillar:**
+- **Security**: NSGs, ASGs, Bastion form a classic three-layer defense (network perimeter, segmentation, access control).
+
+**Key trade-off:** Ease of deployment vs. zero-trust architecture. Lab uses implicit trust within peered VNets; production adds encryption and identity.
+
+- **Operational Excellence**: Bastion centralizes access; NSG per subnet is standard Azure ops pattern.
+- **Reliability**: NSG rule changes are immediate (no deployment delay); but single Bastion is a bottleneck.
+- **Performance Efficiency**: NSGs add negligible latency (~<1 ms). Bastion adds ~100–200 ms round-trip for SSH. Acceptable for admin access, not for data plane.
+- **Cost Optimization**: Bastion is the big cost lever; skipping it saves €140/mo but removes secure access (trade-off: students use VPN or accept the bill).
+
+## 4. Cost / FinOps note
+
+**Monthly cost (if Bastion enabled):**
+- Azure Bastion (Basic SKU): ~€140/mo (largest cost)
+- Bastion Public IP (Standard): €3.40/mo
+- NSGs (3 Hub + 6 Spokes = 9 total): €0 (free)
+- ASGs (6 total): €0 (free)
+- **Total with Bastion: ~€143.40/mo**
+- **Total without Bastion (default): ~€0/mo** (inherits Lab 2.1 costs)
+
+**Lab cost controls:**
+- **Default: parDeployBastion = false** to avoid surprise costs. Enable only when teaching Bastion.
+- If Bastion is enabled, set deployment to 2–3 hours maximum and delete afterward (~€7–10 one-time cost).
+- Delete Bastion immediately after learning; it's rarely needed for subsequent labs (VMs get public IPs in Module 3, or use private endpoints).
+
+**Cleanup reminders after lab:**
+1. **Delete Bastion and its Public IP** if enabled (€140/mo is expensive for learning).
+2. Keep NSGs: Labs 2.3 and Module 3 use them.
+3. Check for orphaned network interfaces: if any VMs were deleted (not yet in this lab), NICs may linger (cost ~€1–2/mo each).
+4. ASGs can stay (free); they'll be used in Module 3.

--- a/module-2-networking/2.3-name-resolution/ARCHITECTURE.md
+++ b/module-2-networking/2.3-name-resolution/ARCHITECTURE.md
@@ -1,0 +1,66 @@
+# Architecture Notes: Lab 2.3 — Name Resolution
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| **Public DNS zone name** | skycraft.example.com (placeholder, not registered) | Use a real registered domain; subdomain of student's own domain | Using a placeholder domain teaches DNS concepts without requiring domain registration. In production, use a real registered domain and delegate nameservers to Azure DNS. TODO(author): Should we provide a "bring your own domain" variant for advanced students? |
+| **Private DNS zone name** | skycraft.internal (arbitrary RFC 1918 name) | Use environment-specific names (dev.internal, prod.internal); use TLD-style (.local, .corp) | Single shared zone teaches VNet Link concept: one zone can serve multiple VNets with auto-registration per VNet. Realistic for small deployments; large production splits zones per environment. |
+| **DNS zone scope** | Private zone links all three VNets (hub + dev + prod); auto-registration only on spokes | Link hub separately with registration disabled, spokes with auto-registration enabled | This design (dns-private.bicep, lines 42–77) reflects reality: shared services (hub) are static; workloads (spokes) are dynamic. Only spokes auto-register VMs so DNS always has current IPs. |
+| **DNS A records** | Placeholder A records (dev-db @ 10.1.3.10, prod-db @ 10.2.3.10) with TTL=300s | Automatic records via auto-registration; conditional forwarders to on-premises; round-robin CNAME | Placeholder records teach zone structure. Real databases get auto-registered once VMs exist. TTL=300s (5 min) balances freshness and query load; production tunes per workload SLA. |
+| **Load Balancer SKU** | Standard SKU, Regional tier | Basic SKU (retired); Global tier | Standard LB is required for production (Basic deprecated ~2025). Regional tier is correct for single-region hub-spoke. Regional enables zone-redundancy if VMs are deployed across zones. |
+| **LB health probe config** | TCP probes on game ports (3724 auth, 8085 world); 15s interval, 2 failed probes = down | HTTPS probes (require app HTTP endpoint); 30s interval; 3 failed probes | TCP probes are simple and don't require application endpoints. 15s interval (aggressive) detects failures quickly in lab. Production might use 30s+ to reduce false positives. Interval = probe sent every N seconds. numberOfProbes = how many failures before marking unhealthy. 15s × 2 = 30s to fail over; acceptable for game servers. |
+| **LB rule load distribution** | Default (5-tuple hash: src IP, src port, dest IP, dest port, protocol) | SourceIP affinity (sticky sessions); SourceIPProtocol affinity (more aggressive stickiness) | Default hash distributes traffic fairly across backends. Sticky sessions help with game server state (player connections persist on one server). Lab uses default for simplicity; production would evaluate per-game requirements. |
+| **Public DNS records** | Two A records (dev, play) pointing to LB IPs; one CNAME (game → play) | Wildcard entry (*); SRV records for service discovery; geodistribution (Traffic Manager) | Simple two-record setup teaches DNS fundamentals. Wildcard would catch misspellings. SRV records are advanced. Geodistribution requires Azure Traffic Manager (future). |
+| **Backend pool strategy** | Empty pools at deployment time (VMs added in Module 3) | Pre-populate with NIC IDs; use VMSS instead of single VMs | Empty pools teach the concept: backend pools are *templates*. Module 3 adds actual VMs. VMSS would auto-scale but adds complexity. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| **DNS zone ownership** | Azure-hosted DNS zone in resource group | Nameserver delegation from domain registrar; zone apex delegation (@) | Lab's skycraft.example.com is *not* registered; it's a placeholder. Real production must register the domain and delegate NS records to Azure's nameservers (output from dns-public.bicep, line 77). Without delegation, external DNS queries won't resolve. |
+| **Private DNS auto-registration** | VNet links configured, but no VMs exist yet to auto-register | VMs auto-register via DHCP; DNS is immediately available to other resources | Lab configures the *capability* (auto-registration enabled on dev/prod links). Real usage appears in Module 3. Shows how DNS scales: add a VM, it self-registers, no manual DNS entry needed. |
+| **LB backend capacity** | No backends deployed (empty pools, ready for VMs) | Load Balancer deployed with Autoscale (VMSS) or pre-warmed VMs; health probes actively monitor | Lab leaves backends empty. Production deploys at least 2 backends per pool for HA; health probes detect and skip unhealthy backends in real-time. |
+| **Health probe verification** | Probes are configured but VMs don't exist to respond | Probes fail immediately (all backends marked unhealthy); LB marks pools as "down"; monitoring alerts fire | Lab's health probes exist but have nothing to probe. In Module 3, when VMs are added, probes will fail until game servers listen on ports 3724/8085. This teaches: if health probes fail, traffic doesn't route. |
+| **Geographic distribution** | Single region (Sweden Central) | Multi-region with Traffic Manager (failover to another Azure region or on-premises) | Lab is single-region. Global SkyCraft would use Traffic Manager to distribute game traffic across regions (e.g., EU vs. NA). |
+| **SSL/TLS termination** | No HTTPS configured on LB | Application Gateway (Layer 7) with SSL certificates, end-to-end encryption, WAF rules | Lab uses TCP Layer 4 load balancing. Production game servers would use HTTPS for account pages and TLS for game data. LB can't terminate HTTPS at Layer 4; would need Application Gateway. |
+| **DNS query logging** | No observability on DNS queries | Azure Diagnostics → Log Analytics, DNS query analytics, anomaly detection | Lab has no DNS observability. Production logs every query to detect suspicious patterns (e.g., DNS exfiltration) and validate auto-registration is working. |
+| **TTL strategy** | Fixed TTL=300s for A records | Dynamic TTL based on backend health (fast fail-over) or query source (internal vs. external) | Lab's fixed TTL is simple. Production might use lower TTL (60s) on internal DNS for faster updates, higher TTL (3600s) on public DNS to reduce query load. |
+| **LB persistence** | No session affinity (default hash) | Stateful backends with session replication or distributed cache (Redis) | Game servers are stateful (player session). Default hash tries to keep same player on same server, but *imperfect* (can hash to different server on port change). Real game servers would replicate state or use shared DB (covered in Module 4). |
+
+## 3. Well-Architected lens (light)
+
+**Dominant pillar:**
+- **Reliability**: Load Balancer distributes traffic and detects failures; Public DNS and Private DNS provide redundant name resolution across regions (potential).
+- **Performance Efficiency**: Standard LB tier enforces zone-redundancy awareness; health probes route traffic only to healthy backends.
+
+**Key trade-off:** Simplicity vs. resilience. Lab uses single LB per region (no active-active failover), and placeholder DNS records (not real domain).
+
+- **Operational Excellence**: LB centralizes traffic ingestion; Private DNS simplifies internal service discovery.
+- **Security**: Private DNS hides internal topology from external queries; health probes validate only responding backends get traffic.
+- **Cost Optimization**: Standard LB is ~€20/mo + data processing. Private DNS is ~€0.40/mo. Game is free. Public DNS is ~€0.50/mo.
+
+## 4. Cost / FinOps note
+
+**Monthly cost (if left running):**
+- 2 Standard Load Balancers (dev + prod): 2 × €20 = €40
+- Data processing through LBs (~10 GB outbound): ~€1.50 (rough estimate; scales with traffic)
+- 2 Standard Public IPs (LB frontend IPs, already counted in Lab 2.1): already included
+- 1 Public DNS Zone (skycraft.example.com): ~€0.50
+- 1 Private DNS Zone (skycraft.internal): ~€0.40
+- Private DNS zone links (3 VNets × 2 zones): €0 (free)
+- **Total: ~€42.40 / month** (additive to Lab 2.1)
+
+**Lab cost controls:**
+- LB is the big cost. If not actively learning LB, stop the deployment and delete.
+- DNS zones are cheap (~€0.90/mo combined) and can stay.
+- Public IPs stay (inherited from Lab 2.1; only bill if not disassociated).
+
+**Cleanup reminders after lab:**
+1. Delete Load Balancers if not testing in Module 3 (€20 each).
+2. Delete Public DNS zone if not using it (€0.50/mo is negligible, but good practice).
+3. Keep Private DNS zone: it's used for service discovery in Module 3+ (VMs will auto-register and query it).
+4. Keep Private DNS zone links: they're free and enable resource discovery.
+5. Verify no orphaned resources: check for unattached Public IPs (if LB was deleted but PIP remained).

--- a/module-3-compute/3.1-infrastructure-as-code/ARCHITECTURE.md
+++ b/module-3-compute/3.1-infrastructure-as-code/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# Architecture Notes: Lab 3.1 — Infrastructure as Code
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Region allowance | swedencentral, westeurope, northeurope | Single region only | Multiple regions teach multi-region awareness; students can experiment with failover regions without redeploying. |
+| VNet sizing | /16 per environment (Hub 10.0.0.0/16, Dev 10.1.0.0/16, Prod 10.2.0.0/16) | Tightly sized /24 or /25 | Generous spacing keeps the lab uncluttered; students can add subnets without re-addressing. In production, you size based on actual VM forecasts and leave headroom for growth. |
+| Subnet segmentation | Three /24 subnets per spoke (AuthSubnet, WorldSubnet, DatabaseSubnet) | Single flat subnet per VNet | Segmentation teaches network layering early; each subnet gets its own NSG, preventing uncontrolled lateral movement. |
+| Hub VNet purpose | Bastion host only (AzureBastionSubnet /26) | Hub for shared services (DNS, routing, egress) | Simplified for a lab; production hubs hold firewall, DNS forwarders, and central egress inspection. |
+| Load Balancer SKU | Standard, Regional tier | Basic LB (deprecated) | Standard is now the only supported option; teaches modern best practices. Regional tier prevents cross-region asymmetry. |
+| NSG rules | Bastion SSH (from 10.0.0.0/26), service ports (3724 Auth, 8085 World from any source) | Restrict service ports to VNet only | Public inbound on game ports teaches port mapping; production closes these to VNet+known client ranges only. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Network isolation | NSGs only, no firewall | Azure Firewall or NVA in hub | Stateless NSG rules cannot inspect encrypted traffic or enforce application-layer policies. Enterprise deployments centralize inspection. |
+| DNS | Azure-provided default (internal only) | Private DNS Zones + conditional forwarder | Required for custom domain names (e.g., auth.skycraft.local) and cross-VNet name resolution. |
+| VNet Peering | None shown; assumes manual setup | Hub-spoke with auto-peering via automation | The lab assumes Lab 3.1 creates RGs and networks; peering is typically automated or done in a separate orchestration step. |
+| Public IP allocation | Static on Load Balancer | Static with auto-release / reserved addresses | Lab uses Static to keep the public IP stable during the lab. Production reserves public IPs to avoid IP exhaustion in shared subscriptions. |
+| Tagging discipline | Common tags on all resources (Project, Service, CostCenter, ManagedBy, DeploymentDate) | Team/Owner, ApplicationId, DataClassification, Automation owner | Lab tags enable cost tracking and resource management; production adds fields for automation handoff and compliance auditing. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Operational Excellence (IaC-first, templated, repeatable)
+- **Cost Management:** Generous sizing and static allocation teach students to resize later; production uses reserved instances or spot VMs.
+- **Reliability:** Availability zones are prepared (zone selection in parameters) but NSGs/LB rules can block traffic if misconfigured; production adds health probes and network policies.
+- **Security:** NSG-only defense is simple but flat; no encryption in transit on NSGs.
+- **Performance:** Standard LB with TCP health checks covers basic needs; production adds HTTP path-based routing and connection draining.
+
+## 4. Cost / FinOps note
+
+**Monthly recurring cost (if left on, all resources 24/7)**:
+- 1 Standard Load Balancer: ~€15/mo
+- 1 Static Public IP: ~€3/mo
+- 3 Resource Groups: free
+- 3 Virtual Networks: free
+- NSGs: free
+- **Total**: ~€18/mo for networking foundation alone.
+
+**Lab cost controls**:
+- No VMs or compute in this lab, so minimal active costs.
+- Public IP can be deallocated when not in use (frees the IP charge but reserves the name).
+
+**Cleanup reminder after the lab**:
+- Delete the Public IP (if deallocated, still incurs ~€3/mo reservation cost).
+- Delete Load Balancer (frees ~€15/mo).
+- Delete VNets (no storage cost but keeps the address space reserved).
+- Leave Resource Groups empty or delete entirely.

--- a/module-3-compute/3.2-virtual-machines/ARCHITECTURE.md
+++ b/module-3-compute/3.2-virtual-machines/ARCHITECTURE.md
@@ -1,0 +1,60 @@
+# Architecture Notes: Lab 3.2 — Virtual Machines
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| VM SKU default | Standard_B2s (2 vCPU, 4 GB RAM, burstable) | Standard_D2s_v3 (fixed performance, costlier), Standard_B1s (smaller, insufficient for game servers) | B2s is the "sweet spot" for a lab: burstable CPU is cheap (~€30/mo), sufficient for light loads, and teaches students the "burst concept" before graduating to fixed-SKU VMs in production. |
+| VM SKU options | B1s, B2s, B2ms, D2s_v3, D4s_v3 | Fixed list only | Constrains choices to reasonable options; production leaves SKU open for students to research. |
+| OS Image | Ubuntu 22.04 LTS Gen2 (Canonical, jammy, official) | Ubuntu 20.04 LTS, CentOS, RHEL, Windows | 22.04 is AzerothCore's recommended baseline; Gen2 VMs use UEFI and support new features like Encryption at Host. |
+| OS Disk | 30 GB Standard SSD (StandardSSD_LRS), delete on VM delete | 128 GB, Premium_LRS, retain for snapshots | 30 GB is enough for OS + minimal services; StandardSSD_LRS (~€3.50/mo) is cost-effective. Production sizes based on application footprint and data growth. |
+| VM Count | 2 (Auth in AZ1, World in AZ2) | 1 VM, or 3+ with scale sets | 2 VMs teach availability zone distribution without the complexity of scale sets; students see failover in action if one zone fails. |
+| Availability Zones | Auth in Zone 1, World in Zone 2 | Same zone, or mixed | Different zones ensure a zone failure doesn't knock out both services. Lab shows this; production may use scale sets for auto-replacement. |
+| Data Disk (World VM only) | 64 GB StandardSSD_LRS, Zone 2 | 128 GB, Premium_LRS, separate VM | 64 GB is enough for a game database in a lab; StandardSSD is cost-effective (~€8/mo). Production sizes based on player count and retention policy. Only World VM gets one because it hosts the game database; Auth is stateless. |
+| SSH Authentication | SSH public key only, disable passwords | Allow password auth or certificate | SSH key is more secure and teaches modern practices. Production enforces key rotation and audits key distribution. |
+| System-Assigned Managed Identity | Enabled on all VMs | None, or User-Assigned only | Enables VMs to fetch encryption keys or secrets without storing credentials. Lab keeps it simple; production layers with User-Assigned identities for fine-grained RBAC. |
+| Encryption Strategy | None (default), EncryptionAtHost, AzureDiskEncryption options | None only | Parameterized to teach the trade-off: no encryption is fast and cheap; EncryptionAtHost adds latency but encrypts at the hypervisor; ADE adds key management complexity. |
+| Load Balancer Backend Pools | Both VMs in pools (Auth in auth pool, World in world pool) | Direct public IPs, or all in one pool | Backend pools teach separation of concerns; each service has its own health probe and rule. Direct public IPs would expose both services independently (not using the LB). |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| SSH Access | Via Bastion in hub VNet | Bastion or private jump server | Lab assumes Bastion is set up (Lab 3.1 or earlier); direct SSH from internet to VM is a security risk. Production ensures no public SSH ingress. |
+| Data Disk Encryption | Optional via Azure Disk Encryption (ADE) module | Encryption at Rest mandatory for PII/regulated data | Lab makes encryption optional to show its cost trade-off; production enforces it for compliance (GDPR, HIPAA, etc.). |
+| Monitoring | No logs or alerting | Azure Monitor + Log Analytics + Alert Rules | VMs run without observability; production collects diagnostics, application logs, and CPU/disk alerts. |
+| Backup | No snapshots or backup policy | Automated daily snapshots or Azure Backup | Lab disks are ephemeral; production requires RTO/RPO guarantees. |
+| Public IPs | None on VMs (routed through LB) | Private IPs only, egress via NAT Gateway or Firewall | Lab relies on LB public IP; production avoids public IPs on VMs to reduce attack surface. |
+| VM Agent | Enabled | Required for extensions (monitoring, patching) | Lab enables it for future use; production uses it for auto-patching and guest OS configuration. |
+| Auto-Shutdown | Not configured | Via auto-shutdown policy or budgets | Lab leaves VMs on 24/7; production uses auto-shutdown for dev/test VMs to avoid idle charges. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Reliability (availability zones, managed identity for secure credential handling)
+- **Cost Management:** B2s burstable SKU teaches cost-optimization; auto-shutdown could save ~70% on dev VM cost. StandardSSD is a good middle ground between speed and cost.
+- **Security:** Managed identity enables secure secret retrieval; encryption options teach compliance trade-offs. SSH key-only removes password attack surface.
+- **Operational Excellence:** Parameterized encryption strategy and SKU allow experimentation without code changes.
+- **Performance:** Burstable CPU is sufficient for light auth/world loads; production upgrades to D-series for consistent performance.
+
+## 4. Cost / FinOps note
+
+**Monthly recurring cost (if left on 24/7)**:
+- 2 × Standard_B2s VMs: ~€30 each = €60/mo
+- 2 × 30 GB StandardSSD_LRS OS disks: ~€3.50 each = €7/mo
+- 1 × 64 GB StandardSSD_LRS data disk: ~€8/mo
+- 1 Key Vault (if ADE enabled): ~€0.50/mo
+- **Estimated total**: €75–76/mo with no encryption; ~€77/mo with ADE.
+
+**Lab cost controls**:
+- Enable auto-shutdown on both VMs: reduces cost to ~€10/mo during lab hours (night/weekend off).
+- Delete extra snapshots immediately after backup testing.
+- Deallocate VMs when not actively testing (~€7/mo for disk storage alone).
+
+**Cleanup reminder after the lab**:
+- **Delete both VMs** (resource intensive; frees ~€60/mo compute cost).
+- **Delete orphaned OS disks** if VMs are deleted but disks are retained (still cost ~€7/mo).
+- **Delete data disk** (frees ~€8/mo).
+- Delete NIC resources (minor cost, but clean).
+- Delete or empty Key Vault if ADE was used (reserves the name for 90 days, costing ~€0.50/mo).

--- a/module-3-compute/3.3-containers/ARCHITECTURE.md
+++ b/module-3-compute/3.3-containers/ARCHITECTURE.md
@@ -1,0 +1,56 @@
+# Architecture Notes: Lab 3.3 — Containers
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| ACR SKU | Standard | Basic (~€4.20/mo, minimal storage), Premium (~€420/mo, geo-replication, private endpoints) | Standard (~€20/mo) is the "learning tier": enough storage for a few images, no complex features, not so expensive it stalls learning. Production chooses based on image volume and replication needs. |
+| ACR Authentication | Admin User enabled (username/password) | RBAC + Managed Identity, Service Principal | Admin user is simple to teach; production disables admin user and uses RBAC or service principals to avoid shared credentials. |
+| Container Instances (ACI) | 1 CPU, 1 GB memory, public IP, TCP port 80 | 0.5 CPU / 0.5 GB (lighter, slower), 2+ CPU (heavier, costlier) | 1 CPU / 1 GB is the default "hello world" size; enough to run a simple auth service. Production right-sizes based on profiling (often smaller). Public IP teaches external access; production uses private endpoints. |
+| Container Apps (ACA) | 0.25 CPU, 0.5 GB memory, 1–3 replicas, HTTP concurrency scaling | Dedicated compute (App Service), serverless (Functions) | Container Apps auto-scales on HTTP traffic; this teaches "serverless thinking" while keeping containers simple. Production chooses App Service for stateful apps, Functions for event-driven, or ACA for stateless microservices. |
+| Image Source | ACR (private registry) | Docker Hub (public), Azure Container Registry with custom builds | Private ACR teaches proprietary image management; pulling from hub would require extra steps (az acr build). Lab assumes images are pre-built or built manually; production automates via ACR Tasks or CI/CD pipelines. |
+| Container Registry Credentials | Hardcoded in Bicep (listCredentials() function) | TODO(author): Explain why credentials are safe here | This approach exposes the registry password in template outputs; production uses Managed Identity and Key Vault to avoid storing credentials in code. |
+| Ingress | External (public FQDN) for both ACI and ACA | Private endpoints + API Gateway | Public ingress teaches direct container access; production places containers behind a firewall or API gateway to control traffic. |
+| Monitoring | Logging to Azure Monitor (Container Apps only) | Application Insights, custom logging | ACA sends logs to Monitor by default; ACI has no explicit logging. Production exports logs to Log Analytics for querying and alerting. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Image Management | Assumes images exist or are built manually | Automated CI/CD pipeline (ACR Tasks, GitHub Actions) | Lab expects users to run `az acr build` manually; production auto-builds on git push. |
+| Secrets Management | Registry credentials in template outputs | Stored in Key Vault, fetched at deploy time | Listing credentials in outputs exposes them in the deployment history. Production uses Key Vault references (identityRef). |
+| Scaling | ACA: static rules (1–3 replicas, HTTP concurrency) | Dynamic scaling based on custom metrics (CPU, queue depth, custom telemetry) | Lab scaling is basic; production adds Kafka/Service Bus triggers, custom KEDA scaler rules. |
+| VNet Integration | ACI: public IP only; ACA: no explicit VNet binding | Private endpoints, VNet integration, network policies | Lab containers are internet-exposed; production keeps them private and routes through API Gateway or Ingress Controller. |
+| Persistence | No volumes or state storage | Persistent volumes (Azure Files, Blob), stateless design | Lab containers are ephemeral; production uses volumes for databases or caches, or redesigns to be truly stateless. |
+| Security | Admin user enabled, public images | RBAC, Managed Identity, image signing, vulnerability scanning | Lab trusts all images; production scans for vulnerabilities (Trivy, Aqua) and signs images (Notary). |
+| Cost Optimization | Always-on instances | Spot instances, scheduled scale-down, multi-tenancy | Lab runs 24/7; production uses auto-shutdown for non-production environments. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Operational Excellence (containers teach immutability and reproducibility)
+- **Cost Management:** ACR Standard (~€20/mo) is reasonable for learning; ACI at 1 CPU (~€30/mo on-demand) and ACA at 0.25 CPU (~€7.50/mo on-demand) show cost differences. Auto-scale on ACA demonstrates efficient resource use.
+- **Security:** ACR SKU and admin user model expose security decisions; switching to RBAC teaches least privilege.
+- **Reliability:** Multiple replicas (1–3) in ACA teach redundancy without the complexity of Kubernetes.
+- **Performance:** Container-native scaling on HTTP metrics (concurrency) is simpler than VM CPU-based scaling.
+
+## 4. Cost / FinOps note
+
+**Monthly recurring cost (if left on 24/7)**:
+- ACR Standard: ~€20/mo (shared across all labs if reused)
+- ACI (1 CPU, 1 GB, always-on): ~€30/mo compute + storage for image pulls
+- ACA (0.25 CPU, 0.5 GB, 1–3 replicas, average 2): ~€15/mo compute + ~€20/mo Container Apps Environment
+- **Estimated total**: €85/mo with both ACI and ACA running.
+
+**Lab cost controls**:
+- Deploy ACI **or** ACA, not both, to halve the cost.
+- Use spot instances (if available for containers) for further savings.
+- Delete images from ACR after the lab to avoid indefinite storage charges.
+
+**Cleanup reminder after the lab**:
+- **Delete Container App Environment** (frees ~€20/mo even if apps are idle).
+- **Delete ACI instance** (frees ~€30/mo).
+- **Delete ACR or clear all images** (frees at least storage costs; ACR registry itself is ~€20/mo).
+- Images in ACR storage cost additional per GB (~€0.02/GB/mo); large images left in ACR add up.
+- Orphaned Container Apps Environments with no apps still incur charges; delete these immediately.

--- a/module-3-compute/3.4-app-service/ARCHITECTURE.md
+++ b/module-3-compute/3.4-app-service/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Architecture Notes: Lab 3.4 — App Service
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| App Service Plan SKU | Premium V4 P0V4 (1 vCPU, 1.75 GB RAM, auto-scaling enabled) | B1 Basic (~€11/mo, no slots), S1 Standard (~€60/mo, simpler), P1v3 (~€115/mo, higher performance) | P0V4 (~€115/mo) is costly for a lab but includes Deployment Slots and VNet Integration. Lab justifies the cost by teaching advanced features; production chooses B1 for simple blogs, S1 for scaling needs, P1+ for demanding apps. |
+| Runtime Stack | Node 20 LTS (Linux) | Python 3.9+, .NET 6, Java 11, Go | Node.js is lightweight and familiar to many students; Linux keeps costs lower and aligns with the game server theme. Production chooses based on team expertise and app requirements. |
+| OS | Linux | Windows | Linux App Service is slightly cheaper and aligns with the SkyCraft narrative (Ubuntu VMs in earlier labs). Windows is required for ASP.NET or IIS-dependent apps. |
+| Deployment Slots | One staging slot | No slots, or multiple (e.g., staging + canary) | Single staging slot teaches blue-green deployments without overcomplicating cost. Production may add canary or QA slots. |
+| Auto-Scaling Rules | CPU > 70% scale out (+1 instance), CPU < 30% scale in (−1 instance), 1–3 replicas | No auto-scaling, fixed 3 instances, or aggressive rules (threshold 50%) | These rules are conservative and teach auto-scaling fundamentals. Production tuning depends on application metrics (request count, custom telemetry). |
+| VNet Integration | Configured but no backend services connected | Full hub-spoke with private access to DB/cache | Lab shows the configuration without using it; production uses it to reach private databases or in-VNet APIs securely. |
+| HTTPS/TLS | Required (httpsOnly: true) | Optional | Enforces security by default. Production always enables this. |
+| System-Assigned Managed Identity | Enabled on the Web App | None, or User-Assigned for multi-app scenarios | Simplifies secret retrieval (e.g., from Key Vault) without storing credentials in app config. |
+| Connection Draining | Not explicitly configured | Enabled on load balancer rules | Graceful shutdown is important; production sets connection drain timeout on any front-facing LB. |
+| Backups | Not configured | Automated daily/weekly backups with retention | Lab relies on stateless app design (no persistent data); production backs up app content and database separately. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Application Code | Empty/default Node app | Real dashboard or monitoring service | Lab deploys a placeholder; production integrates with logging, dashboards, and authentication systems. |
+| Deployment | Manual slot swap or FTP | Automated CI/CD (Azure DevOps, GitHub Actions) | Lab teaches slot mechanics; production automates build, test, and release. |
+| Custom Domain | Azure-assigned domain (e.g., dev-skycraft-swc-app01.azurewebsites.net) | Custom domain + SSL certificate (Let's Encrypt, managed cert) | Lab uses the default; production uses branded domains and auto-renewing certs. |
+| Authentication | None (public access) | Azure AD / Entra ID, or OAuth 2.0 | Lab exposes the app publicly; production protects it behind identity verification. |
+| Monitoring & Alerting | Minimal (auto-scale rules only) | Application Insights, Log Analytics, custom alerts | Lab doesn't collect app logs or metrics; production exports performance and error data. |
+| Database Connectivity | VNet Integration configured but no backend | Private endpoint to Azure SQL or CosmosDB | Lab shows the config; production uses it to reach a secure database in the spoke VNet. |
+| Cost Optimization | No cost controls (runs 24/7 on P0V4) | Scheduled scale-down, spot instances, right-sizing | P0V4 is expensive; production may downsize to S1 or add auto-shutdown for non-prod. |
+| CDN / Caching | No caching or CDN | Azure Front Door or CDN for static assets | Lab serves everything from a single region; production caches CSS/JS globally. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Operational Excellence (managed platform, slots enable safe deployments)
+- **Cost Management:** P0V4 is the "learning tax"; production downsizes to S1 or B1. Auto-scaling is enabled but conservative; production tunes thresholds based on load testing.
+- **Reliability:** Deployment slots teach safe deployments without downtime. Auto-scaling to 3 instances provides redundancy. VNet Integration enables private access to backend services.
+- **Security:** System-managed identity enables secret retrieval; HTTPS-only enforces encrypted transit. Production adds Azure AD authentication and DDoS protection (Azure Front Door).
+- **Performance:** Auto-scaling on CPU metric is basic; production adds custom metrics (request count, custom business logic).
+
+## 4. Cost / FinOps note
+
+**Monthly recurring cost (if left on 24/7)**:
+- App Service Plan P0V4 (1 instance): ~€115/mo
+- Staging slot (charged as another instance if running): ~€115/mo (unless you deallocate it to save cost)
+- Auto-scale to 3 instances (if sustained under high load): ~€345/mo total
+- **Estimated typical cost**: €115–230/mo (production slot + occasional scaling).
+
+**Lab cost controls**:
+- **Deallocate the staging slot when not testing** (frees ~€115/mo). Slots still exist but don't consume compute.
+- Use auto-shutdown policy if available (though App Service doesn't natively support auto-shutdown like VMs do); could switch to B1 (~€11/mo) after learning.
+- Monitor scaling events; if the app never scales, downsize the plan to S1 (~€60/mo).
+
+**Cleanup reminder after the lab**:
+- **Delete the App Service Plan** (frees all associated costs). Deleting the web app without the plan leaves the plan running and billing.
+- **Delete the staging slot first**, then the web app, then the plan (dependencies matter).
+- **Delete VNet Integration rule** if no backend services depend on it (no direct cost but keeps the config clean).
+- Exported logs in Log Analytics continue to incur ingestion + retention charges; delete old workspaces or set retention to 30 days.

--- a/module-4-storage/4.1-storage-accounts/ARCHITECTURE.md
+++ b/module-4-storage/4.1-storage-accounts/ARCHITECTURE.md
@@ -1,0 +1,44 @@
+# Architecture Notes: Lab 4.1 — Storage Accounts
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Redundancy per environment | Production & Platform: GRS; Development: LRS | All environments GRS or all LRS | GRS costs 2x but teaches high-availability for critical data; LRS in dev reflects cost-consciousness in non-critical environments. AZ-104 objective covers both strategies. |
+| Access tier | Hot (all environments) | Cool or Archive | Hot tier is default and most common; archive tier requires longer retrieval latency (not yet relevant in Lab 4.1). Students learn tiering in Lab 4.2. |
+| Public network access | Enabled (default) | Disabled with firewall | Lab 4.4 locks this down; starting open simplifies initial deployment and CLI testing. Production would deny by default. |
+| Blob/File soft delete | Enabled (7 days) | Disabled or longer retention | 7 days balances accidental deletion recovery with compliance. AZ-104 emphasizes soft delete for data protection. |
+| Infrastructure encryption | Optional (disabled by default) | Always enabled | Infrastructure encryption cannot be changed post-creation; disabled here lets students apply it only if explicitly requested. Production would likely enable it. |
+| Blob versioning | Optional (disabled by default) | Always enabled | Versioning adds cost and complexity; introduced in Lab 4.2 after containers are deployed. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Network isolation | Public endpoints accessible from internet | Private endpoints + service endpoints only | Lab 4.1 teaches resource creation; Lab 4.4 teaches network security. Production needs zero public exposure for sensitive data. |
+| Encryption key management | Microsoft-managed keys (default) | Customer-managed keys (CMK) in Key Vault | CMK provides key rotation control and regulatory compliance (HIPAA, PCI-DSS); added complexity for a lab. |
+| Access controls | Shared key access enabled | Disable shared keys, RBAC only | Shared keys are legacy; RBAC is role-based least privilege. Lab doesn't enforce this choice. |
+| Monitoring & diagnostics | Not configured in this lab | Storage Analytics + Azure Monitor logs | Lab 4.5 (or later module) would add monitoring. Storage diagnostics help with troubleshooting and capacity planning. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Security & Cost Optimization
+- **Reliability:** GRS in production enables failover to secondary region; reduces data loss RTO/RPO.
+- **Cost Optimization:** LRS in dev saves ~50% vs GRS; soft delete retention period (7d) is minimal while protecting against accidents.
+- **Security:** Public network access (enabled by default) is simplified here; firewall rules deferred to Lab 4.4.
+- **Operational Excellence:** Soft delete and versioning reduce manual recovery effort; no logging/diagnostics in this lab.
+
+## 4. Cost / FinOps note
+
+- **Monthly cost (rough, assuming 1 TB stored):**
+  - Platform GRS: ~€36/month (€0.036/GB/month × 1000 GB)
+  - Dev LRS: ~€18/month (€0.018/GB/month × 1000 GB)
+  - Prod GRS: ~€36/month
+  - **Total: ~€90/month for 1 TB across all three environments**
+- **Lab cost controls:** Resource groups can be deleted after lab; no auto-shutdown needed (storage is always-on, but can be deleted immediately).
+- **Cleanup reminder:**
+  - Delete storage accounts to stop billing (data is deleted with the account unless backed up elsewhere).
+  - Soft-deleted blobs/containers remain for 7 days after deletion; no additional cleanup needed.
+  - Ensure no external locks on storage accounts before RG deletion.

--- a/module-4-storage/4.2-blob-storage/ARCHITECTURE.md
+++ b/module-4-storage/4.2-blob-storage/ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Architecture Notes: Lab 4.2 — Blob Storage
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Container isolation | Production: 4 private containers; Dev: 1 public container | All private with lifecycle, all public with RBAC | Mirrors real scenarios: prod stores game-assets, backups, configs, logs (all private); dev has public demo asset for student learning. Public access in dev teaches the risk. |
+| Public access model | Account-level public access (Dev only) | Container-level public access | Account-level is the least-secure option; Lab 4.4 teaches disabling it. Container-level is more granular (not shown here). |
+| Lifecycle tiers | Prod logs: Hot→Cool (30d)→Cold (90d)→Archive (180d)→Delete (365d); backups: Archive (7d) | All tiers kept Hot, or delete after X days | Tiering teaches cost optimization: Cool/Cold/Archive are cheaper per-GB but have retrieval latency. Backups → Archive quickly (7d) reflects backup storage model. Logs aging to deletion (365d) teaches retention policies. |
+| Blob versioning | Enabled (Prod only) | Disabled, or versioning with immutable snapshots | Versioning enables rollback of accidental overwrites; disabled in Dev (less critical). Production would enable for game-assets and configs. |
+| Lifecycle filters | Prefix matching on `player-backups/` | No prefix filtering, or wildcard patterns | Prefix filtering teaches selective rules; backups in a dedicated prefix is a real pattern. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Retention compliance | Lifecycle auto-deletes after 365 days | Multi-year retention with legal hold / immutable storage | Game logs may have regulatory or audit requirements (GDPR, SOC2). Immutable blobs prevent deletion once set. |
+| Rehydration cost | Not addressed | Explicitly budget rehydration cost when retrieving from Archive | Rehydration can take hours and cost 10–100x more than initial storage. Production must track access patterns. |
+| Backup strategy | Backups archived after 7 days (still deletable) | Immutable snapshots or cross-region replication | Lab doesn't teach active/passive backup failover; snapshots are point-in-time but mutable. |
+| Change tracking | Versioning enabled (no change feed) | Change feed + event-driven pipelines | Versioning tracks overwrites; change feed integrates with Event Grid for real-time processing. Lab is simpler. |
+| Access logging | Not configured | Storage Analytics logs all read/write; sent to Monitor | Logging provides audit trail for security/compliance; deferred to monitoring module. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Cost Optimization & Compliance
+- **Cost Optimization:** Lifecycle policies tiering logs down automatically reduce storage costs by 60–80%; Archive tier at €0.004/GB/month vs Hot at €0.018/GB/month.
+- **Reliability:** Versioning (Prod) enables rollback; multi-region replication would be next step.
+- **Security:** Public access in Dev is intentional teaching tool; Prod is fully private. RBAC/SAS token controls not shown here (Lab 4.4).
+- **Compliance:** 365-day retention before deletion reflects audit requirements; immutable storage not yet needed.
+
+## 4. Cost / FinOps note
+
+- **Monthly cost (assuming 1 TB in Prod, 100 GB in Dev):**
+  - Prod Hot (50% of 1 TB): €18
+  - Prod Cool (30% of 1 TB, assume 40 days): ~€3
+  - Prod Cold (15% of 1 TB, assume 120 days): ~€0.30
+  - Prod Archive (5% of 1 TB, assume 270 days): ~€0.05
+  - Dev Hot (100 GB public demo): ~€1.80
+  - **Total: ~€23/month** (vs ~€36 without tiering)
+  - **Savings: ~€13/month (~35% reduction) from Hot-only**
+- **Rehydration costs:** If retrieving 1 GB from Archive: ~€0.02 retrieval + Standard re-hydration latency (hours). Communicate this in lab guide.
+- **Cleanup reminder:**
+  - Lifecycle policies don't delete immediately; archived blobs in 365+ day retention remain until deletion task runs.
+  - Snapshots (if any) must be manually deleted; not covered by container deletion.
+  - Soft-deleted containers/blobs still occupy storage for 7 days; plan cleanup accordingly.

--- a/module-4-storage/4.3-azure-files/ARCHITECTURE.md
+++ b/module-4-storage/4.3-azure-files/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture Notes: Lab 4.3 — Azure Files
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Protocol | SMB only (implied by StorageV2 + fileServices) | NFS (requires Premium SKU) | SMB is standard for Windows/AD environments; NFS requires Premium tier, which costs 5–10x more and is overkill for a lab. NFS taught in advanced modules. |
+| Tier / SKU | Standard_GRS (Prod) / Standard_LRS (Dev) | Premium storage, Hot/Cool variants | Standard Hot is the baseline; tiering requires StorageV2 but not a separate Premium account. Premium (~€0.16/GB provisioned) is for low-latency gaming/databases; standard file shares teach the common case. |
+| File share quotas | skycraft-config: 100 GB; skycraft-shared: 500 GB | Unlimited, or very small (10 GB) | Quotas teach capacity planning; realistic sizes (100/500 GB) reflect small game-server configs and shared assets. Unlimited would mask over-provisioning. |
+| File share snapshots | Not configured in this lab | Always enabled, scheduled | Snapshots provide point-in-time recovery; deferred to a later lab. Lab 4.3 focuses on provisioning and access. |
+| AD integration | Not configured in this lab | On-premises AD or Entra ID | AD integration adds complexity; Lab 4.3 focuses on share creation. Lab 4.5+ or module-3 (Identities) would cover this. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Access method | Via Azure Portal / Azure CLI | SMB mount from Windows/Linux VM with AD authentication | Portal is for verification; production mounts via SMB using AD credentials, not account keys. |
+| Performance tier | Hot (standard) | Cool for infrequent access, Premium for latency-critical apps | Hot suits active game-server configs; Cool is cheaper for archives. Premium is for dedicated performance (IOPS/throughput guarantees). |
+| Snapshots & backup | Manual only | Automated snapshots + Azure Backup integration | Lab creates shares but doesn't automate point-in-time recovery. Production needs scheduled snapshots. |
+| Encryption | Default (Microsoft-managed) | Customer-managed keys in Key Vault | Lab doesn't address CMK; encryption at rest is always on. |
+| Network isolation | Public network access enabled | Service endpoints or private endpoints + deny public access | Lab 4.4 tightens this; initially open for testing. Production would firewall off public access. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Reliability & Operational Excellence
+- **Reliability:** GRS in Prod enables failover; file share quota limits prevent accidental exhaustion.
+- **Operational Excellence:** File shares simplify SMB mount for VMs; snapshots (not yet shown) reduce RTO for data loss.
+- **Cost Optimization:** Standard SKU is cheapest shared storage; Premium reserved for low-latency workloads.
+- **Security:** Public network access simplified here; restricted in Lab 4.4 via private endpoints or service endpoints.
+
+## 4. Cost / FinOps note
+
+- **Monthly cost (assuming 100 GB config + 500 GB shared shares = 600 GB total in Prod):**
+  - Standard GRS, Hot: 600 GB × €0.036/GB = ~€21.60/month
+  - Transactions (estimate 10,000/month): ~€0.10
+  - **Total: ~€22/month**
+- **Dev (Standard LRS, ~100 GB):**
+  - 100 GB × €0.018/GB = ~€1.80/month
+  - **Combined: ~€24/month**
+- **Premium alternative cost (if used):**
+  - Premium File Share provisioned at 100 GB: €16/month (fixed) for tier; 500 GB: €80/month.
+  - **Premium would cost ~€96/month; Standard saves ~€72/month for this lab.**
+- **Lab cost controls:** File shares can be shrunk or deleted after lab; no auto-snapshot cleanup needed in this lab.
+- **Cleanup reminder:**
+  - Soft-deleted file shares (if any) occupy storage for 14 days before purge.
+  - Snapshots (if created manually) must be deleted individually; not auto-cleaned with share deletion.
+  - Ensure no locks on shares before RG deletion.

--- a/module-4-storage/4.4-storage-security/ARCHITECTURE.md
+++ b/module-4-storage/4.4-storage-security/ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# Architecture Notes: Lab 4.4 — Storage Security
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Firewall default action | Deny (Production environment) | Allow (default for Lab 4.1–4.3) | Deny-by-default is the "zero trust" principle; students graduate from open (Lab 4.1) to locked-down (Lab 4.4). Production always starts with Deny. |
+| Network rules | VNet service endpoint on WorldSubnet only | Multiple subnets, IP ranges, or private endpoints | VNet rule via service endpoint is simpler than private endpoint (no NIC, no DNS zone); teaches the common case. Private endpoints are advanced (Lab 4.5 or separate security module). |
+| IP rules | Optional client IP parameter | Hardcoded list, or CIDR ranges | Optional client IP is flexible for different labs/environments; hardcoding would break labs in different networks. |
+| Private endpoints | Not configured in this lab | Always deployed for Prod | Private endpoints hide storage from public DNS and internet entirely; deferred to advanced module. Service endpoints still route traffic via public IP internally. |
+| Customer-managed keys | Not configured in this lab | Always for Prod | CMK complexity (Key Vault + RBAC + key rotation) exceeds AZ-104 scope; encryption at rest is always on (Microsoft-managed by default). |
+| Diagnostic logging | Not configured in this lab | Always enabled (Monitor logs, Storage Analytics) | Logging is critical for audit/compliance but requires separate module (Lab 4.5 or Monitoring module). |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Network access | Service endpoint (VNet rule) + optional IP firewall | Private endpoints for all access; no public endpoint | Service endpoint still routes via public infrastructure; private endpoints use private IP and DNS, zero internet exposure. |
+| Access keys | Shared key access still enabled | Disable shared keys, RBAC + Managed Identity only | Lab doesn't disable shared keys; production would eliminate them after confirming all clients use RBAC. |
+| Public endpoint | Firewall applied but endpoint exists | No public endpoint registered in DNS/portal | Firewall blocks access but endpoint still resolvable; production would remove public endpoint entirely. |
+| SAS token scope | Not addressed | Time-bound, IP-scoped SAS with specific container/blob | Lab creates dev-assets container for token testing; actual token scoping taught in Module 1 (Identities). |
+| Monitoring | Not configured | Alerts on anomalous access, failed auth, egress anomalies | Lab doesn't enable Storage Analytics or Monitor integration; production tracks all access. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Security
+- **Security:** Firewall default-deny + VNet rules enforce least-privilege network access. Disabling public access and requiring service endpoints (or private endpoints) eliminates internet-facing risk.
+- **Reliability:** Service endpoints ensure Azure services can bypass the firewall (bypass: AzureServices); production critical path is protected.
+- **Operational Excellence:** Firewall rules are transparent to legitimate clients in the allowed subnet; reduces operational surprises.
+- **Cost Optimization:** Service endpoints cost nothing; private endpoints cost ~€7/month each + egress. Lab chooses service endpoints for cost.
+
+## 4. Cost / FinOps note
+
+- **Monthly cost (no new storage, just security configuration):**
+  - Service endpoints: €0 (built into VNet)
+  - Storage account with Deny firewall: no premium cost (regular GRS/LRS rate applies)
+  - **Total incremental cost: €0**
+- **If private endpoints were used instead:**
+  - 1 private endpoint × ~€7/month = €7
+  - Egress data (cross-region or external): €0.02–€0.05/GB depending on destination
+  - **Total: €7 + egress**
+- **Lab cost controls:** Firewall rules don't auto-create resources; student manually specifies subnet / client IP during deployment.
+- **Cleanup reminder:**
+  - Network rules (service endpoint, IP firewall) are deleted with storage account or can be manually cleared before RG deletion.
+  - Private endpoint NICs (if later used) are orphaned if storage account is deleted; must be cleaned separately.
+  - Diagnostic settings (if added) may send logs to Log Analytics; ensure log retention policies are set before cleanup to avoid unexpected egress charges.

--- a/module-5-monitoring-maintenance/5.1-azure-monitor/ARCHITECTURE.md
+++ b/module-5-monitoring-maintenance/5.1-azure-monitor/ARCHITECTURE.md
@@ -1,0 +1,46 @@
+# Architecture Notes: Lab 5.1 — Azure Monitor
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Log Analytics SKU | PerGB2018 | Pay-as-you-go (Standalone) | PerGB2018 remains available and is cost-effective for small labs; students learn the modern ingestion model that charges per GB of data sent rather than reserved capacity. |
+| Data retention | 30 days | 90, 365 days or indefinite | 30 days balances learning (enough data to analyze trends) with cost control; extended retention can quickly become expensive (€0.50+ per GB per month) and is unnecessary for lab exercises. |
+| DCR data sources | VM Insights perfcounters + syslog | Application Insights, custom counters, Windows Events | Covers the most common monitoring signals (CPU, memory, disk, system logs); teaches the modern data collection model without overwhelming students with config options. |
+| Metric alert threshold | CPU > 80% on prod VM | 50%, 90%, dynamic | 80% is a reasonable middle ground for a lab VM; triggers often enough to demonstrate alerting without noise, but not so sensitive as to spam on normal variance. |
+| Storage account diagnostics | StorageRead & StorageWrite logs | All category options | Captures the essential audit trail of blob access for compliance auditing; excludes Delete operations to reduce log volume in a teaching context. |
+| Action Group receivers | Email notification only | Teams, Slack, webhooks, logic apps | Email is universally available and demonstrates core alerting; escalation to external systems is deferred to production labs. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Public network access | Log Analytics workspace allows public ingestion & query | Private Endpoints for ingestion/query; on-prem Data Collectors or Azure Arc agents | Removes the need for complex network plumbing (NSGs, firewall rules) so students focus on the monitoring concept; production must restrict data path to private networks to meet compliance and security boundaries. |
+| Workspace redundancy | Single region (Sweden Central) | Multi-region replication with read access or secondary workspace | Lab data is non-critical; production requires geo-redundancy so that regional outages do not block queries or ingestion. |
+| DCR association scope | One VM for Insights collection | Cohesive agent policy across 100+ VMs via user-assigned MI | Lab uses direct association to one resource ID passed as a parameter; production relies on tag-based rules and managed identities to keep DCR assignment idempotent and scalable. |
+| Alert notification delivery | Synchronous email via Action Group (subject to retry) | Email + SMS + voice call + PagerDuty routing with incident response playbook automation | Lab demonstrates the alert dispatch mechanism; production ties alerts into incident lifecycle (ITSM ticketing, on-call escalation). |
+| Diagnostic settings retention | None (infinite retention in workspace) | Retention policy on diagnostic settings to auto-delete after 30–90 days in archive tier | Lab keeps all data to maximize learning; production manages retention to balance compliance hold periods with cost. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Operational Excellence
+  - Central monitoring foundation; teaches structured observability (metrics, logs, traces).
+- **Security:** Public network access simplifies the lab but violates least-privilege in production.
+  - Private endpoints + managed identities required for enterprise.
+- **Reliability:** Alert thresholds and single-region setup adequate for teaching; no multi-region or failover.
+- **Performance:** 60-second metric evaluation window is a reasonable real-time balance for cost and noise.
+- **Cost:** PerGB2018 with 30-day retention is the cheapest path for learning volumes (<10 GB/month = ~€23/month).
+
+## 4. Cost / FinOps note
+
+- **Monthly cost estimate:** Log Analytics Workspace ~€0 base + €2.30 per GB ingested (PerGB2018). A lab with 5 VMs and moderate logging (~3 GB/month) costs ~€7 total.
+- **Reduction tactics:**
+  - 30-day retention avoids old-data storage cost.
+  - Syslog + perf counters only; no verbose application traces.
+  - Email action group free (no SMS or voice charges).
+- **Cleanup reminder:**
+  - **Do not delete the workspace until the lab is complete.** Deleting the RG does not immediately delete the workspace; it may persist and incur ingestion costs if agents are still writing to it.
+  - After lab completion: Delete the workspace explicitly to stop ingestion charges. If flow logs from Lab 5.3 are also routing to this workspace, coordinate deletion to avoid query failure in dependent labs.
+  - Storage account diagnostic settings remain after RG deletion; verify no data continues to flow to any workspace that you intend to delete.

--- a/module-5-monitoring-maintenance/5.2-business-continuity/ARCHITECTURE.md
+++ b/module-5-monitoring-maintenance/5.2-business-continuity/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Architecture Notes: Lab 5.2 — Business Continuity & Disaster Recovery
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Recovery Services Vault redundancy | Locally Redundant Storage (LRS) | Geo-Redundant Storage (GRS) | LRS keeps lab costs minimal (~€2–4/month per protected VM) and is sufficient for a learning exercise; production requires GRS or GZRS to survive region-wide outages and meet RTO/RPO SLAs. |
+| Backup frequency | Daily (via Deploy-Bicep.ps1 policy creation) | Hourly or multiple times per day | Daily balances RPO (up to 24 hours of loss acceptable) with cost and simplicity; production may require 4-hourly or 1-hourly recovery points depending on mission-critical data. |
+| Retention period | 30 days for daily backups | 365 days or tiered (daily 30d, weekly 1y, monthly 5y) | 30 days is enough to recover from a recent corruption or accidental deletion in a lab; production uses longer retention for compliance (HIPAA 7-year, SOX 10-year) and archival cost tiers. |
+| Vault storage access | Public network enabled | Private Endpoints, no public access | Lab simplicity; production isolates backup vault traffic to private networks to satisfy compliance and reduce ransomware blast radius. |
+| Soft delete | Enabled (default) | Disabled | Soft delete prevents accidental vault deletion and is enabled by default in Bicep; production always uses soft delete (14-day grace period) to prevent catastrophic data loss. |
+| Blob operational backup (Backup Vault) | Continuous, 30-day retention | Snapshot-based (cheaper but lower granularity) | Continuous backup captures every block change; useful for learning destructive workloads; production chooses based on RTO/RPO (snapshots faster to restore, continuous granular point-in-time). |
+| Backup Vault identity | System-assigned managed identity | User-assigned MI (recommended) | System-assigned is simpler for a single vault in a lab; production uses user-assigned MI to support role inheritance across multiple vaults and cleaner identity hygiene. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Vault geo-redundancy | LRS (single region) | GRS or GZRS (cross-region replication) | Lab data loss is acceptable; production must survive regional failures and meet RTO/RPO guarantees in SLAs. |
+| Backup targets | 1–2 VMs in the lab | 50–1000+ VMs with tiered priority (critical, standard, non-critical) | Lab uses hardcoded VM resource ID in metric alert; production automates target discovery via tags or policy to avoid manual registration and support scaling. |
+| Retention policy complexity | Single 30-day policy for all backups | Tiered: daily 30d, weekly 1y, monthly 5y, archive after 1 year | Lab keeps data simple; production archives to cold storage (€0.01/GB/month) after hot retention window to meet compliance while controlling cost. |
+| Backup verification & restore testing | Manual verification in lab guide | Automated restore test every 30 days via runbook | Lab trusts backups are valid; production performs periodic restore drills to catch silent backup failures before they are needed in an outage. |
+| Monitoring | Diagnostic logs route to Log Analytics (Lab 5.1 workspace) | Backup reports in dedicated dashboard, alert on backup job failure | Lab collects logs; production activates alerts so failed backups are detected and remediated within SLA (typically 4 hours). |
+| Cross-tenant recovery | Not applicable | Backup Vault may support cross-subscription/tenant restore scenarios | Out of scope for this lab; relevant for enterprise multi-cloud disaster recovery. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Reliability & Resilience
+  - Backup is the foundational tool for recovery from data loss and ransomware; teaches backup design and testing discipline.
+- **Security:** Soft delete and RBAC on vault access prevent unauthorized deletion or tampering.
+  - Private Endpoints and deny-public-access policies required in production.
+- **Cost:** LRS + 30-day retention keeps lab cost ~€4.50/month per VM (<50 GB).
+  - Tiered retention (archive after 1 year) essential in production for long-term compliance retention.
+- **Operational Excellence:** Diagnostic logs to workspace enable backup health monitoring and trend analysis.
+
+## 4. Cost / FinOps note
+
+- **Monthly cost estimate:**
+  - Recovery Services Vault: Free (no base cost).
+  - Instance Protection (per VM per month): ~€4.50 for a Standard_B2s VM with <50 GB incremental backups.
+  - Backup Vault: Free (no base cost).
+  - Blob operational backup: ~€0 for <100 GB stored (continuous, 30-day retention).
+  - **Total for 2 VMs:** ~€9/month.
+- **Reduction tactics:**
+  - LRS storage is cheaper than GRS (GRS adds ~2x cost).
+  - 30-day retention avoids long-term storage fees; archive tiers reduce per-GB cost to €0.01/month after hot period.
+  - Deploy-Bicep.ps1 uses Azure Backup REST API to create policies (idempotent), avoiding repeated creation attempts.
+- **Cleanup reminder:**
+  - **Do not delete the vault immediately after lab completion.** Soft delete is enabled; the vault will be in a "soft-deleted" state for 14 days. Deletion will fail if any protected instance still references it.
+  - Stop all backup jobs first: Disable backup on the 2 protected VMs, allow the next backup cycle to complete, then delete the vault.
+  - After soft-delete grace period (14 days), the vault is permanently deleted and recovery is no longer possible.
+  - Backup Vault also supports soft delete; follow the same 14-day grace period process.
+  - Diagnostic settings on the vault itself will be deleted with the vault, but logs already sent to the Log Analytics workspace (Lab 5.1) remain and continue to incur ingestion charges unless the workspace is also deleted.

--- a/module-5-monitoring-maintenance/5.3-network-monitoring/ARCHITECTURE.md
+++ b/module-5-monitoring-maintenance/5.3-network-monitoring/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Architecture Notes: Lab 5.3 — Network Monitoring & Diagnostics
+
+> Learning context. These notes explain the reasoning behind the lab's design and how it would change in a real environment. The lab deliberately favors clarity over production hardening.
+
+## 1. Design decisions & trade-offs
+
+| Decision | Choice in this lab | Alternatives considered | Why this choice (in a learning context) |
+|---|---|---|---|
+| Flow Log type | Virtual Network Flow Log (v2, JSON) | NSG Flow Logs (v1), deprecated after June 2025 | VNet Flow Logs capture all IP traffic at the network interface layer and are the modern standard; NSG Flow Logs are deprecated and will be unsupported after June 2025, so the lab teaches the future-proof approach. |
+| Flow Log version | Version 2 (v2) | Version 1 (v1, legacy) | v2 includes additional fields (TCP flags, flow state: OK/Denied) that enable deeper troubleshooting; v1 is simpler but loses diagnostic value. Teaching v2 aligns with current Azure best practices. |
+| Flow Log retention | 7 days | 30, 90, 365 days or indefinite | 7 days is enough for a typical troubleshooting window (DNS issues, intermittent connectivity); longer retention multiplies storage cost (€0.10/GB for Hot, €0.03/GB for Warm) without benefit in a learning lab. |
+| Traffic Analytics interval | 10 minutes | 1, 60 minutes | 10 minutes provides a reasonable refresh rate for analyzing traffic patterns without excessive aggregation; 1-minute is too noisy, 60-minute loses temporal resolution. |
+| Traffic Analytics destination | Log Analytics Workspace (centralized) | Storage account only (cheaper, logs-only) | Routing to a workspace enables rich KQL queries and integration with other telemetry (metrics, diagnostic logs); storage-only is cheaper but requires separate parsing tools. Lab emphasizes integrated monitoring. |
+| Connection Monitor protocol | TCP/22 (SSH) | ICMP ping, HTTP, custom TCP | SSH is relevant to the lab topology (Auth Server connectivity between hub and spoke) and demonstrates TCP layer health checks; ICMP may be blocked by NSGs in production so TCP is more realistic. |
+| Connection Monitor frequency | Every 5 minutes | Every 1, 30 seconds | 5 minutes balances prompt detection of outages (~5 min alert latency) with cost of test traffic; every 30 seconds would double the test load. |
+| Flow Log storage format | JSON in blob storage | CSV (legacy), Parquet (newer) | JSON is human-readable and widely supported by analytics tools; Parquet is more efficient for large-scale batch analytics but adds tooling complexity. |
+
+## 2. Lab simplifications vs production
+
+| Aspect | What the lab does | What production would require | Why it matters |
+|---|---|---|---|
+| Flow log scope | Single VNet (production) | Multiple VNets + NSGs + subnets with variable retention per scope | Lab captures one VNet's traffic; production segments by security boundary (e.g., high-sensitivity subnets retain 90 days, general retain 30 days) and enforces retention policies per NSG to meet compliance. |
+| Traffic Analytics cost | ~€2/GB analyzed (combined flow log + analytics cost) | Aggregated across 100s of VNets; per-VNet cost can exceed €500/month | Lab cost is modest (~€5–10/month for 5–10 GB of logs); production carefully budgets TA and sometimes disables it for non-critical VNets or uses sampling. |
+| Connection Monitor endpoints | 1 source (prod VM), 1 destination (dev VM) | Mesh of 20+ endpoints across regions & datacenters with custom thresholds per path | Lab tests a single critical path (hub-spoke SSH); production creates multi-endpoint meshes to catch cross-region latency, asymmetric routing, and datacenter availability issues. |
+| Connection Monitor actions | Output to Log Analytics (queryable) | Output to Action Group, ITSM ticketing, auto-remediation runbooks | Lab logs results; production integrates failed probes into incident response (PagerDuty, ServiceNow, Auto-Scale). |
+| Flow log storage redundancy | LRS in a single storage account | RA-GRS or immutable blob snapshots for compliance archives | Lab trades redundancy for cost; production requires cross-region replication so that storage region failure does not block access to forensic logs. |
+| Flow log ingestion latency | ~10 minutes to Log Analytics | Real-time ingestion for incident response, or batch for compliance analytics | Traffic Analytics aggregates at 10-minute intervals; production may stream to event hubs for real-time threat detection (ransomware, DDoS) or batch to cold storage for compliance audits. |
+
+## 3. Well-Architected lens (light)
+
+- **Dominant pillar:** Operational Excellence & Reliability
+  - Network monitoring is critical to diagnosing connectivity failures, latency, and packet loss; teaches structured network troubleshooting.
+- **Security:** Flow logs provide forensic audit trail for intrusion detection, policy violations, and compliance audits.
+  - Immutable storage and longer retention (30–90 days) required in production for compliance (PCI-DSS, HIPAA).
+- **Cost:** VNet Flow Logs are free; Traffic Analytics cost ~€2/GB analyzed (significant at scale). Lab limits scope to one VNet.
+- **Performance:** Connection Monitor probes every 5 minutes; tight thresholds (10% failure rate, 100 ms RTT) ensure quick detection of user-impacting issues.
+
+## 4. Cost / FinOps note
+
+- **Monthly cost estimate:**
+  - VNet Flow Logs (captured, stored): Free for the log capture; storage in blob account ~€0.08/GB (Hot tier, 7-day retention). A single VNet with 2 VMs generating 10 GB/week = ~€3/month storage.
+  - Traffic Analytics: ~€2/GB analyzed. Same 10 GB/week = ~€8/month.
+  - Connection Monitor: Free (first 100 test endpoints), then €0.10 per endpoint per day. Lab uses 2 endpoints = free tier.
+  - **Total for lab:** ~€11/month.
+- **Reduction tactics:**
+  - Reduce retention from 30 to 7 days (saves 75% storage cost).
+  - Use sampling or target only critical VNets for Traffic Analytics (if monitoring many VNets, disable TA on non-critical ones).
+  - Connection Monitor: Increase probe frequency from 5 minutes to 30 minutes to reduce test traffic and alert noise.
+  - Delete or disable Flow Logs on VNets after lab (free to disable, but logs continue to accumulate in storage until manually purged).
+- **Cleanup reminder:**
+  - **Flow Logs persist in the storage account even after the lab RG is deleted.** The NetworkWatcherRG is automatically provisioned by Azure and may outlive manual RG cleanup.
+  - Delete the VNet Flow Log resource explicitly to stop new logs from being written.
+  - Flow logs already in the storage account blob container must be manually deleted or moved to archive tier to avoid ongoing Hot tier charges.
+  - Traffic Analytics data in Log Analytics Workspace (Lab 5.1) will continue to accumulate; delete the Flow Log source to stop analytics ingestion, then purge old data from the workspace.
+  - If Connection Monitor is left running, it will continue to probe the network indefinitely, potentially triggering alerts in production-like systems; disable or delete the Connection Monitor resource immediately after troubleshooting.


### PR DESCRIPTION
## Summary

Adds an **architecture commentary layer** on top of the existing AZ-104 labs.
The layer explains *why* each lab is built the way it is, what the lab
deliberately simplifies, and how a real production deployment would differ.

- 14 new `ARCHITECTURE.md` files (one per lab) following the template from
  `skycraft-architecture-layer-brief.md`. Labs 1.1 and 1.2 carry lightweight
  notes (sections 1+2); all other labs cover the full template (sections 1–4).
- New `DESIGN-DECISIONS.md` at the repo root: index linking every per-module
  note and 14 cross-cutting themes (hub-spoke, region lock, naming, tag
  taxonomy, personas→RBAC, env stratification, redundancy, SKU floors,
  defense-in-depth, encryption posture, cost discipline, data protection,
  central monitoring, IaC maturity).
- README gains a short "Architecture Layer" section pointing at the index.
  Existing README content is untouched.

**Additive only.** No labs were modified, no Bicep or PowerShell touched.

## TODO(author) markers to resolve

Four spots flagged for author judgment (rationale could not be inferred from
code alone):

- `module-2-networking/2.2-secure-access/ARCHITECTURE.md:13` — Why these
  specific game ports (3724, 8085)? Assumed WoW-compatible defaults; confirm
  with game server docs.
- `module-2-networking/2.2-secure-access/ARCHITECTURE.md:16` — Egress NSG
  strategy is currently allow-all. Add explicit egress examples to an
  advanced challenge section?
- `module-2-networking/2.3-name-resolution/ARCHITECTURE.md:9` —
  `skycraft.example.com` is a placeholder. Provide a "bring-your-own-domain"
  variant for advanced students?
- `module-3-compute/3.3-containers/ARCHITECTURE.md:14` — ACR registry
  password is exposed via `listCredentials()` in Bicep outputs. Explain why
  this is acceptable in the lab context, or migrate to managed identity.

## Notes for reviewer

- Per-lab notes cite actual file paths and (where useful) line numbers in
  the Bicep so the reader can jump from rationale to code.
- Cost estimates are rough EUR/month figures based on Sweden Central public
  pricing at the time of writing; verify before quoting.
- Commits are split per module (Module 1 → Module 5) plus a final commit for
  the root index and README pointer, so the layer can be reviewed in
  logical chunks.

## Heads-up about develop

One of the commits in this layer (root index + README pointer) was
inadvertently first applied to `develop` during the session and appears to
have been auto-pushed to `origin/develop` (commit `3662043`). The same
content was then cherry-picked onto this branch as `a0576ed`. If `develop`
is later merged forward, the duplicate may show up — worth a quick check
before the next develop→main merge.

## Test plan

- [ ] Verify every link in `DESIGN-DECISIONS.md` resolves to a real
      `ARCHITECTURE.md` file.
- [ ] Verify the new section in `README.md` renders correctly and that no
      pre-existing content was changed.
- [ ] Skim each `ARCHITECTURE.md` for accuracy against the Bicep it
      references; fix any `TODO(author):` markers.