### PR TITLE
docs: adopt GitHub Flow + introduce ADR folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,27 @@ Before submitting a Pull Request (PR), please review our project standards to en
 - **[PowerShell Standards](docs/powershell-standards.md)**: Scripting style, error handling, and formatting.
 - **[Bicep Standards](docs/bicep-standards.md)**: Infrastructure as Code modules and parameters.
 
+## 🌿 Branching & PR workflow
+
+SkyCraft follows **GitHub Flow** (see [ADR-0001](docs/adr/0001-use-github-flow.md)):
+
+- `main` is the only long-lived branch.
+- All work happens on short-lived branches: `feature/*`, `fix/*`, `docs/*`, `chore/*`.
+- Changes land on `main` exclusively via Pull Request, **squash-merged** for linear history.
+- Branch protection rules on `main` are documented in [ADR-0002](docs/adr/0002-branch-protection-rules.md).
+
+For multi-commit work — and for any work driven by an automated agent — use a
+`git worktree` to isolate the feature from the main checkout (see
+[ADR-0003](docs/adr/0003-worktree-branch-discipline.md) for the rationale and
+the exact commands).
+
 ## 🛠️ How to Contribute
 
 1.  **Fork the Repository**: Create your own copy of the project.
-2.  **Create a Branch**: Use a descriptive name (e.g., `feat/lab-3.1-vm`, `fix/typo-lab-1.2`).
+2.  **Create a Branch off `main`**: Use a descriptive name (e.g., `feature/lab-3.1-vm`, `fix/typo-lab-1.2`).
 3.  **Make Changes**: Implement your feature or fix.
 4.  **Verify**: Run the relevant `Test-Lab.ps1` scripts to ensure no regressions.
-5.  **Submit a Pull Request**: Describe your changes clearly and link to any relevant issues.
+5.  **Submit a Pull Request against `main`**: Describe your changes clearly and link to any relevant issues. PRs are squash-merged.
 
 ## 🧪 Testing
 

--- a/docs/adr/0001-use-github-flow.md
+++ b/docs/adr/0001-use-github-flow.md
@@ -1,0 +1,74 @@
+# ADR-0001: Use GitHub Flow (drop `develop`)
+
+- **Status:** Accepted
+- **Date:** 2026-05-26
+- **Deciders:** @mbiszczanik
+
+## Context
+
+SkyCraft started with a Git Flow-style branching model: `main` for stable
+content, `develop` as integration branch, `feature/*` for work in progress.
+The visible cost of this model in a solo project has been:
+
+- Ongoing `develop` ↔ `main` synchronisation work (see commits
+  `ff49c69 fix: sync main into develop ...`, `06cc88a Develop (#33)`,
+  `84555eb Develop (#30)`).
+- A second protected branch to configure and reason about — branch
+  protection rules, sync expectations, merge direction.
+- An extra surface area for accidents: during the architecture-layer
+  session on 2026-05-26, a commit was inadvertently applied to `develop`
+  instead of the feature branch and then auto-synced to `origin/develop`,
+  forcing a cherry-pick + reset to recover.
+
+Git Flow was designed for batch releases with multiple developers
+integrating concurrently. SkyCraft has neither: it is a single-maintainer
+learning project with continuous improvement and no release cadence in the
+"v1.2.0" sense.
+
+## Decision
+
+We adopt **GitHub Flow**:
+
+- `main` is the only long-lived branch.
+- All work happens on short-lived branches named `feature/*`, `fix/*`,
+  `docs/*`, `chore/*`.
+- Changes land on `main` exclusively via Pull Request.
+- PRs are merged with **squash merge** for a clean linear history.
+- The `develop` branch is retired.
+
+## Consequences
+
+**What we gain:**
+
+- One protected branch to configure and reason about.
+- No more `develop` ↔ `main` synchronisation commits cluttering history.
+- One fewer merge target to mis-aim at — the class of incident that
+  triggered this ADR cannot recur in the same form.
+- Alignment with how the majority of comparable solo/small OSS projects
+  work today (Astro, htmx, Vite, Tailwind, Bun).
+
+**What we give up:**
+
+- No dedicated integration branch where multiple in-flight features can
+  bake together before promotion. Acceptable: SkyCraft does not currently
+  have multiple concurrent feature branches needing joint testing.
+- No "playground" branch separate from `main`. If we later need one
+  (e.g. for experimental lab variants), we introduce a long-lived
+  `experiment/*` branch with explicit ADR — we do not silently re-add
+  `develop`.
+
+**Follow-up tasks:**
+
+- Delete `develop` from the GitHub remote once any open `develop`-targeted
+  PRs are closed or re-targeted at `main`.
+- Update branch protection on `main` per ADR-0002.
+- Update `CONTRIBUTING.md` to describe the GitHub Flow workflow.
+
+## Alternatives considered
+
+- **Keep Git Flow.** Rejected: the ongoing tax of `develop` ↔ `main` sync
+  has no upside in a solo project without batch releases.
+- **Trunk-based development with no protection on main.** Rejected: even
+  solo, branch protection on `main` catches force-push and accidental
+  delete mistakes, and the PR workflow is the natural place to attach CI
+  later.

--- a/docs/adr/0002-branch-protection-rules.md
+++ b/docs/adr/0002-branch-protection-rules.md
@@ -1,0 +1,79 @@
+# ADR-0002: Branch protection rules for `main`
+
+- **Status:** Accepted
+- **Date:** 2026-05-26
+- **Deciders:** @mbiszczanik
+
+## Context
+
+With ADR-0001 making `main` the only long-lived branch, the protection
+rules on `main` are the entire safety net of the project. They have to
+work for two distinct cases at once:
+
+1. **Solo maintainer day-to-day** — must not block merges of the
+   maintainer's own PRs.
+2. **External contributors via fork PRs** — must still go through review
+   (= the maintainer's approval) before landing.
+
+The previous configuration used **Require approvals ≥ 1**, which is
+self-locking for a single-maintainer project: the maintainer cannot
+approve their own PR, and is the only person with write access who could.
+Every merge therefore required "bypass rules", which works but leaves a
+trail of bypass markers and is not the right mental model.
+
+## Decision
+
+Protection rules for `main` are:
+
+- **Require a pull request before merging** — enabled. No direct pushes
+  to `main`.
+- **Block force pushes** — enabled. Force pushes to `main` are never
+  legitimate.
+- **Restrict deletions** — enabled. `main` cannot be deleted.
+- **Require linear history** — enabled. Squash-merge only; no merge
+  commits on `main`.
+- **Require conversation resolution before merging** — enabled. All
+  review threads must be closed.
+- **Require status checks to pass** — enabled *once CI exists* (currently
+  no `.github/workflows/` in the repo; this rule activates as soon as the
+  first job is added).
+- **Require approvals** — **disabled**, with the explicit understanding
+  that external contributors still need maintainer approval because only
+  the maintainer has merge permission. If/when a second maintainer joins,
+  this is revisited via a new ADR.
+
+Merge method: **squash and merge only**. Other options disabled.
+
+## Consequences
+
+**What we gain:**
+
+- The maintainer's own PRs merge without bypass markers.
+- External PRs still cannot reach `main` without the maintainer pressing
+  Merge, which is the actual review gate.
+- A single, simple set of rules — easy to explain in `CONTRIBUTING.md`.
+
+**What we give up:**
+
+- No formal "two pairs of eyes" gate. Acceptable in a solo project; the
+  PR description + diff review by the maintainer is the eyes.
+- No automated quality gate yet — `Require status checks` is configured
+  but inert until CI exists.
+
+**Follow-up tasks:**
+
+- Add a `.github/workflows/` directory with at minimum: Bicep build/lint,
+  PowerShell `PSScriptAnalyzer`, Markdown lint. Wire those job names into
+  the `Require status checks` list.
+- When a second maintainer is added, write a new ADR re-enabling
+  `Require approvals ≥ 1` and adjust this one's status.
+
+## Alternatives considered
+
+- **Keep `Require approvals ≥ 1` and use admin bypass.** Rejected: every
+  merge is a bypass; loses the signal value of "bypass means something
+  unusual happened".
+- **Repository Rulesets with a bypass list (maintainer always bypasses).**
+  Considered, viable, but more configuration surface than is justified
+  for a single-maintainer project today. Worth re-evaluating if/when a
+  second maintainer joins.

--- a/docs/adr/0003-worktree-branch-discipline.md
+++ b/docs/adr/0003-worktree-branch-discipline.md
@@ -1,0 +1,100 @@
+# ADR-0003: Use git worktrees for multi-commit work
+
+- **Status:** Accepted
+- **Date:** 2026-05-26
+- **Deciders:** @mbiszczanik
+
+## Context
+
+During the architecture-layer session on 2026-05-26, mid-session the
+active branch in the shared working copy switched unexpectedly: a fresh
+`develop → main` merge (`7ee7620`) appeared between commits, and a commit
+intended for `feature/architecture-layer` ended up on `develop` (and was
+then auto-synced to `origin/develop`). Recovery required `cherry-pick` +
+`reset --hard`.
+
+The root cause of the branch switch is still unconfirmed (suspected:
+external process operating in the shared checkout, a hook, or an
+auto-sync tool). What is clear is that any work that:
+
+- spans multiple commits,
+- runs concurrently with other tooling on the same checkout, or
+- is performed by an automated agent that does not visually verify the
+  branch before every operation,
+
+is exposed to this class of mistake.
+
+`git worktree` makes each branch a physically separate directory with its
+own `HEAD`. Operations on one worktree cannot change the branch of
+another. This eliminates the shared-checkout failure mode entirely.
+
+## Decision
+
+For any work that meets **any** of the following criteria, use an isolated
+`git worktree`:
+
+- The work is expected to span **two or more commits**.
+- The work is dispatched to an **automated agent** (Claude Code, IDE
+  extensions doing edits, scripted tooling).
+- The work runs **concurrently** with other ongoing work on the same
+  repository.
+
+The worktree is created as a sibling directory of the main checkout, not
+inside it:
+
+```
+git worktree add -b feature/<name> ../skycraft-<short-name> origin/main
+git -C ../skycraft-<short-name> branch --unset-upstream feature/<name>
+```
+
+The `--unset-upstream` step is deliberate: it prevents accidental `git
+push` from the feature branch onto the base branch.
+
+When work is done and merged, prune the worktree:
+
+```
+git worktree remove ../skycraft-<short-name>
+git branch -d feature/<name>   # after PR is merged
+```
+
+For trivial single-edit / single-commit work — typo fixes, README tweaks
+— a worktree is not required.
+
+## Consequences
+
+**What we gain:**
+
+- The 2026-05-26 class of incident cannot recur: an external `git
+  checkout` in the main repo directory does not affect the worktree's
+  `HEAD`.
+- Multiple features can be worked on in parallel without `git stash`
+  juggling.
+- Agents have a stable workspace that survives external operations on
+  the main checkout.
+
+**What we give up:**
+
+- A small amount of disk space per worktree (one extra working copy of
+  the source tree; `.git/` is shared).
+- One extra step at the start and end of feature work.
+- Shared `.git/` means concurrent ref operations on the *same* branch
+  across worktrees can still collide. We avoid this by using a fresh
+  branch per worktree, which is already the rule.
+
+**Follow-up tasks:**
+
+- Reference this ADR from `CONTRIBUTING.md`'s branching section.
+- If the root cause of the original branch switch is eventually
+  identified (hook, tool, etc.), add a postscript or follow-up ADR.
+
+## Alternatives considered
+
+- **Discipline only — check `git symbolic-ref --short HEAD` before every
+  commit.** Rejected as the primary mechanism: it relies on the operator
+  (or agent) remembering, every single time. Worktrees make the
+  guarantee structural rather than behavioural. Verifying the branch is
+  still a sensible secondary safeguard inside a worktree.
+- **Pre-commit hook that aborts when the branch doesn't match an
+  expected value.** Viable as an additional safety net but does not by
+  itself prevent the shared-checkout race. Worth adding later as a
+  belt-and-braces measure; orthogonal to this ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,56 @@
+# Architecture Decision Records (ADR)
+
+This folder holds the load-bearing decisions behind SkyCraft — process,
+tooling, and architecture. Each ADR is a short, dated note explaining
+**what** was decided, **why** at the time, and **what consequences** the
+decision has.
+
+ADRs are append-only. We don't edit them after they are accepted — we write
+a new ADR that supersedes the old one. That way the *history of the
+project's thinking* stays intact, which is more valuable than a tidy
+"current state" document that hides the reasoning.
+
+## What goes here vs. elsewhere
+
+| Document type | Lives in | Example |
+|---|---|---|
+| Why a decision was made | `docs/adr/` (this folder) | "Why GitHub Flow, not Git Flow" |
+| How a contributor should work | `CONTRIBUTING.md` | "Branch off main, open PR, squash-merge" |
+| Conventions for code style | `docs/bicep-standards.md`, `docs/powershell-standards.md` | "Bicep header block format" |
+| The lab architecture itself | `DESIGN-DECISIONS.md` + per-lab `ARCHITECTURE.md` | "Why hub-spoke topology" |
+| The Azure baseline & personas | `SPECIFICATION.md` | "Warcraft persona → RBAC mapping" |
+
+If you cannot tell where something belongs: process/meta decisions → ADR;
+domain/lab decisions → `DESIGN-DECISIONS.md`.
+
+## How to add a new ADR
+
+1. Copy `template.md` to `NNNN-short-kebab-title.md` (next free number).
+2. Fill in Context / Decision / Consequences. Keep it short — one page if
+   possible. The point is to capture reasoning, not write a thesis.
+3. Open a PR like any other change. The ADR is `Proposed` until merged;
+   then it is `Accepted`.
+4. If a later ADR overrules this one, do not delete or edit this file —
+   change its status to `Superseded by ADR-NNNN` and add a link.
+
+## Status values
+
+- **Proposed** — under discussion in a PR.
+- **Accepted** — merged; this is current policy.
+- **Superseded by ADR-NNNN** — overruled by a later decision; kept for
+  history.
+- **Deprecated** — no longer applies but was never explicitly replaced.
+
+## Format
+
+We use a lightweight [MADR](https://adr.github.io/madr/) style. No
+ceremony, no required sections beyond Context / Decision / Consequences.
+See `template.md`.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-use-github-flow.md) | Use GitHub Flow (drop `develop`) | Accepted |
+| [0002](0002-branch-protection-rules.md) | Branch protection rules for `main` | Accepted |
+| [0003](0003-worktree-branch-discipline.md) | Use git worktrees for multi-commit work | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,30 @@
+# ADR-NNNN: <Short imperative title>
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Deciders:** @<github-handle>
+
+## Context
+
+What problem are we solving, and what state was the project in when this
+decision was made? Include any constraints (time, team size, tooling) that
+shaped the choice — they may not be obvious to a future reader.
+
+## Decision
+
+What we are doing. Be specific and active: "We use X" / "We drop Y", not
+"We might consider".
+
+## Consequences
+
+What changes because of this decision. Cover at least:
+
+- **What we gain.**
+- **What we give up / accept as cost.**
+- **What we must do as a follow-up** (concrete tasks that this decision
+  creates).
+
+## Alternatives considered
+
+Optional, but useful for the non-obvious decisions. One or two sentences
+per alternative, focused on *why it was rejected*, not what it is.


### PR DESCRIPTION
## Summary

Introduces an Architecture Decision Records (ADR) folder under `docs/adr/` and records the first three process decisions for the project, then wires them into `CONTRIBUTING.md`.

- **ADR-0001** — Adopt GitHub Flow; drop the `develop` branch. Motivated by the ongoing `develop` ↔ `main` sync cost and the 2026-05-26 incident where a commit landed on `develop` instead of the intended feature branch.
- **ADR-0002** — Branch protection rules for `main`. Disables `Require approvals` (self-locking for a solo maintainer) while keeping PR-required, no-force-push, linear history, conversation resolution, and status checks (inert until CI exists).
- **ADR-0003** — Use `git worktree` for any work that spans ≥2 commits, runs concurrently, or is dispatched to an automated agent. Eliminates the shared-checkout `HEAD` race that caused the 2026-05-26 incident.
- `docs/adr/README.md` + `docs/adr/template.md` to make future ADRs frictionless.
- `CONTRIBUTING.md` gains a "Branching & PR workflow" section pointing at the three ADRs and updates the contribution steps to reference `main` as the only long-lived branch.

## Follow-up tasks (NOT in this PR)

These are intentionally separated so each ADR has a clean "decision recorded → action taken" trail:

1. **After this PR merges:** delete `develop` from origin (`git push origin --delete develop`).
2. **After this PR merges:** apply the branch protection rules from ADR-0002 in GitHub Settings → Branches.
3. **Future PR:** introduce `.github/workflows/` (Bicep build, PSScriptAnalyzer, Markdown lint) and wire job names into the `Require status checks` list — ADR-0002 reserves that slot.

## Test plan

- [ ] All ADR files render correctly on GitHub (headings, links between ADRs, code blocks).
- [ ] `CONTRIBUTING.md` links to ADR-0001/0002/0003 resolve.
- [ ] No changes to existing labs, scripts, Bicep, or module READMEs — additive only.
- [ ] No `.git/`, `.github/workflows/`, or secret files touched.

## Notes

- Additive change only — no existing content modified beyond the targeted `CONTRIBUTING.md` section additions.
- Authored on a `git worktree` (sibling directory of the main checkout, upstream initially unset) as a self-demonstration of ADR-0003. The branch was pushed to origin only when this PR was opened.