### PR TITLE
test(l004): enforce module README contract on Module 1 too

### DIFF
--- a/tests/Module-Readme-L004.Tests.ps1
+++ b/tests/Module-Readme-L004.Tests.ps1
@@ -35,10 +35,9 @@
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 
-# Module 1's README is still missing the '🏗️ Architecture Overview' Mermaid section (L004 #4).
-# That gap is tracked separately and will be closed on branch task/05-module-1-architecture-overview,
-# which also widens this test to cover module 1. Until then, assert L004 only for modules 2-5.
-$ExcludedModules = @('module-1-identities-governance')
+# All five modules (1-5) now ship the full L004 13-section contract, including the
+# '🏗️ Architecture Overview' Mermaid section. No module is excluded.
+$ExcludedModules = @()
 
 $Modules  = Get-ChildItem -Path $RepoRoot -Directory -Filter 'module-*' |
             Where-Object { $ExcludedModules -notcontains $_.Name } |


### PR DESCRIPTION
## Summary

Standardizes the **L004 module-README contract** so it is enforced uniformly across **all five modules**.

### Finding
The `Module-Readme-L004.Tests.ps1` test excluded `module-1-identities-governance` with a note that its `🏗️ Architecture Overview` Mermaid section was "still missing" and would be added later on a `task/05-...` branch. That branch was never needed — **Module 1's README already ships the complete section**: all 13 L004 sections in order, plus a full Mermaid diagram of the identity/RBAC/governance layer.

### Change
- Removed `module-1-identities-governance` from `$ExcludedModules` (now `@()`).
- Updated the stale comment to reflect that all five modules conform.

### Verification
Replicated the test's assertions against Module 1 locally before un-excluding it: heading count = 13, all 13 emoji+pattern checks pass, and a `mermaid` block is present. Modules 2–5 are unchanged and already pass. CI (Repository Standards / Pester) now covers Module 1 as well.

## Scope / notes
- Test-only change; no module content modified. The READMEs already met the contract.
