### PR TITLE
chore(security): add dependabot config and vulnerability reporting policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Keep the GitHub Actions used by the CI workflow current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -1,5 +1,14 @@
 # Security Policy
 
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately. Open the repository's
+**Security** tab and choose **Report a vulnerability** to file a private report
+through GitHub
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+Do not open a public issue for security problems.
+
 ## Security Best Practices for Students
 
 When using these course materials:


### PR DESCRIPTION
Standardizes the security baseline: adds `.github/dependabot.yml` (weekly github-actions updates) and a private vulnerability reporting section to the existing security policy. Part of cross-repo security standardization.