### PR TITLE
ci: bump markdownlint-cli2-action from v19 to v24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           config: .markdownlint.jsonc
           globs: |


### PR DESCRIPTION
Closes #66

Bumps `DavidAnson/markdownlint-cli2-action` from `v19` to `v24` (Node 24 runtime).

The other two items from issue #66 were already resolved by Dependabot:
- `gitleaks/gitleaks-action` v2 → v3 landed in #67
- `actions/checkout` v6 → v7 landed in #69