### PR TITLE
fix: suppress residual PSScriptAnalyzer warnings

### DIFF
--- a/module-1-identities-governance/1.1-entra-users-groups/scripts/New-LabUser.ps1
+++ b/module-1-identities-governance/1.1-entra-users-groups/scripts/New-LabUser.ps1
@@ -42,6 +42,7 @@
 #Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.Users, Microsoft.Graph.Groups
 
 [CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Lab script; -DemoMode dry-run switch fulfils the ShouldProcess intent.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TenantId', Justification = 'Documented public parameter retained for the lab interface; reserved for explicit tenant targeting.')]
 param (
     [Parameter(Mandatory = $false, HelpMessage = "The Microsoft Entra Tenant ID.")]

--- a/module-1-identities-governance/1.1-entra-users-groups/tests/New-LabUser.Tests.ps1
+++ b/module-1-identities-governance/1.1-entra-users-groups/tests/New-LabUser.Tests.ps1
@@ -19,6 +19,11 @@
 
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
+# PSAvoidUsingInvokeExpression: intentional — injects the generator function
+# extracted via AST so it can be tested in isolation without sourcing the full script.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
+param()
+
 BeforeAll {
     $script:ScriptPath = Join-Path $PSScriptRoot '..\scripts\New-LabUser.ps1' | Resolve-Path
     $script:ScriptText = Get-Content -Raw -LiteralPath $script:ScriptPath
@@ -74,17 +79,17 @@ Describe 'New-LabUser.ps1 — random password generator' {
     }
 
     It 'produces a 20-character password' {
-        $pwd = New-LabRandomPassword
-        $pwd.Length | Should -Be 20
+        $password = New-LabRandomPassword
+        $password.Length | Should -Be 20
     }
 
     It 'produces passwords with all four character classes' {
         1..20 | ForEach-Object {
-            $pwd = New-LabRandomPassword
-            $pwd | Should -Match '[A-Z]'
-            $pwd | Should -Match '[a-z]'
-            $pwd | Should -Match '[0-9]'
-            $pwd | Should -Match '[!@#\$%\^&\*\(\)\-_=\+\[\]\{\}]'
+            $password = New-LabRandomPassword
+            $password | Should -Match '[A-Z]'
+            $password | Should -Match '[a-z]'
+            $password | Should -Match '[0-9]'
+            $password | Should -Match '[!@#\$%\^&\*\(\)\-_=\+\[\]\{\}]'
         }
     }
 

--- a/module-2-networking/2.1-virtual-networks/scripts/Deploy-Networking.ps1
+++ b/module-2-networking/2.1-virtual-networks/scripts/Deploy-Networking.ps1
@@ -42,6 +42,7 @@
 #Requires -Modules Az.Accounts, Az.Network
 
 [CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Deploy script; idempotent guard (Get-before-New) and az --what-if provide the dry-run safety net.')]
 param(
     [Parameter(Mandatory = $false)]
     [ValidateSet('swedencentral', 'northeurope')]
@@ -144,6 +145,7 @@ try {
 Write-Host "`n=== Task 5: Configuring VNet Peering ===" -ForegroundColor Cyan
 
 function New-SkyCraftPeering {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper; parent script guards idempotency via Get-before-New.')]
     param($Name, $SrcVnet, $DstVnetId, $RgName)
     Write-Host "Creating Peering: $Name..." -ForegroundColor Yellow
     try {
@@ -169,6 +171,7 @@ New-SkyCraftPeering -Name "prod-to-hub" -SrcVnet $prodVnet -DstVnetId $hubVnet.I
 Write-Host "`n=== Task 6: Creating Public IP Addresses ===" -ForegroundColor Cyan
 
 function New-SkyCraftPip {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper; parent script guards idempotency via Get-before-New.')]
     param($Name, $RgName, $Tags)
     Write-Host "Creating PIP: $Name..." -ForegroundColor Yellow
     try {

--- a/module-2-networking/2.2-secure-access/scripts/Deploy-Security.ps1
+++ b/module-2-networking/2.2-secure-access/scripts/Deploy-Security.ps1
@@ -45,6 +45,8 @@
 #Requires -Modules Az.Accounts, Az.Network
 
 [CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Deploy script; interactive Bastion prompt and idempotent Get-before-New guards cover ShouldProcess intent.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ProdVnetName', Justification = 'Used as -VnetName in Set-SubnetSecurity calls; PSSA nested-scope false positive.')]
 param(
     [Parameter(Mandatory = $false)]
     [ValidateSet('swedencentral', 'northeurope')]
@@ -134,6 +136,7 @@ foreach ($config in $asgConfigs) {
 Write-Host "`n=== Task 2: Creating Network Security Groups ===" -ForegroundColor Cyan
 
 function New-SkyCraftNSG {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper; parent script guards idempotency via Get-before-New.')]
     param($Name, $RG, $Env)
     Write-Host "Creating NSG: $Name..." -ForegroundColor Yellow
     try {

--- a/module-2-networking/2.3-name-resolution/scripts/Deploy-DNS.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Deploy-DNS.ps1
@@ -19,6 +19,7 @@
 #Requires -Modules Az.Accounts, Az.Dns, Az.Network
 
 [CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Deploy script; idempotent Get-before-New guards cover ShouldProcess intent.')]
 param(
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
@@ -144,6 +145,7 @@ if ($privZone) {
 
 # 2. Create DB Records (Placeholder)
 function New-PrivateDnsRecord {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper; parent script guards idempotency via Get-before-New.')]
     param($Name, $Ip)
     $rec = Get-AzPrivateDnsRecordSet -ResourceGroupName $PlatformRG -ZoneName $PrivateDnsZoneName -Name $Name -RecordType A -ErrorAction SilentlyContinue
     if (-not $rec) {
@@ -163,6 +165,7 @@ New-PrivateDnsRecord -Name 'prod-db' -Ip '10.2.3.10'
 Write-Host "`n=== Task 3: Linking Virtual Networks ===" -ForegroundColor Cyan
 
 function New-PrivateDnsLink {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper; parent script guards idempotency via Get-before-New.')]
     param($LinkName, $VnetRG, $VnetName, $AutoReg)
     
     $link = Get-AzPrivateDnsVirtualNetworkLink -ResourceGroupName $PlatformRG -ZoneName $PrivateDnsZoneName -Name $LinkName -ErrorAction SilentlyContinue

--- a/module-2-networking/2.3-name-resolution/scripts/Deploy-LoadBalancer.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Deploy-LoadBalancer.ps1
@@ -19,6 +19,8 @@
 #Requires -Modules Az.Accounts, Az.Network
 
 [CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Deploy script; idempotent Get-before-New guards cover ShouldProcess intent.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Location', Justification = 'Consumed inside New-SkyCraftLB via parent-scope resolution; PSSA nested-scope false positive.')]
 param(
     [Parameter(Mandatory = $false)]
     [ValidateSet('swedencentral', 'northeurope')]
@@ -66,6 +68,7 @@ $Tags = @{
 }
 
 function New-SkyCraftLB {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper; parent script guards idempotency via Get-before-New.')]
     param (
         [string]$ResourceGroupName,
         [string]$LbName,


### PR DESCRIPTION
Closes #65

### Changes

**`PSUseShouldProcessForStateChangingFunctions` (8 suppressions)**
- `New-LabUser.ps1` — `-DemoMode` dry-run switch covers the ShouldProcess intent
- `Deploy-Networking.ps1` + helpers `New-SkyCraftPeering`, `New-SkyCraftPip`
- `Deploy-Security.ps1` + helper `New-SkyCraftNSG`
- `Deploy-DNS.ps1` + helpers `New-PrivateDnsRecord`, `New-PrivateDnsLink`
- `Deploy-LoadBalancer.ps1` + helper `New-SkyCraftLB`

All suppression justifications document the existing idempotency guard (Get-before-New) or interactive prompt that covers the ShouldProcess intent.

**`PSAvoidUsingInvokeExpression` (`New-LabUser.Tests.ps1`)**
Script-level suppression — `Invoke-Expression` is intentional: it injects the AST-extracted `New-LabRandomPassword` function into the test session for isolated unit testing.

**`PSAvoidAssignmentToAutomaticVariable` × 2 (`New-LabUser.Tests.ps1`)**
Renamed `$pwd` → `$password` in the random password generator tests (`$pwd` is a PowerShell alias for `$PWD`).

**`PSReviewUnusedParameter` × 2**
- `Deploy-Security.ps1` — `$ProdVnetName` is passed to `Set-SubnetSecurity`; PSSA nested-scope false positive
- `Deploy-LoadBalancer.ps1` — `$Location` is consumed inside `New-SkyCraftLB` via parent-scope resolution; PSSA nested-scope false positive