### PR TITLE
docs: AVM-first foundations for issue #62 v2 (PR 0/6)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,6 +55,18 @@ jobs:
           }
           if ($failed) { exit 1 }
 
+      - name: Build all Bicep parameter files
+        shell: pwsh
+        run: |
+          $failed = $false
+          Get-ChildItem -Recurse -Filter '*.bicepparam' | ForEach-Object {
+              Write-Host "::group::$($_.FullName)"
+              az bicep build-params --file $_.FullName --stdout 1>$null
+              if ($LASTEXITCODE -ne 0) { $failed = $true }
+              Write-Host '::endgroup::'
+          }
+          if ($failed) { exit 1 }
+
   markdownlint:
     name: Markdownlint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Verify every PowerShell file parses
+        shell: pwsh
+        run: |
+          $failed = $false
+          $root = (Get-Location).Path
+          Get-ChildItem -Path . -Recurse -File |
+              Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
+              ForEach-Object {
+                  $parseErrors = $null
+                  [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$parseErrors) | Out-Null
+                  if ($parseErrors.Count -gt 0) {
+                      $failed = $true
+                      $rel = $_.FullName.Substring($root.Length + 1).Replace('\', '/')
+                      foreach ($e in $parseErrors) {
+                          Write-Host "::error file=$rel,line=$($e.Extent.StartLineNumber),col=$($e.Extent.StartColumnNumber)::$($e.Message)"
+                      }
+                  }
+              }
+          if ($failed) { exit 1 }
+          Write-Host 'All PowerShell files parse.'
+
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pester guard `tests/Avm-Module-Pinning.Tests.ps1`: every `br/public:avm/...` reference must pin an exact semver, each AVM module must resolve to a single version repo-wide, and `bicepconfig.json` must not define registry aliases.
+
+### Changed
+
+- Bicep standards rewritten to an **AVM-first** policy (issue #62 v2): Azure Verified Modules consumed directly from `main.bicep` entry points, exact-version pinning with a repo-wide catalogue, canonical tag set (`Project`/`Environment`/`CostCenter`/`Owner`), an explicit-`dependsOn` rule, lab-friction override principle, and a documented Lab 3.1 hand-written-modules exception.
+- Lint workflow now builds every `.bicepparam` file with `az bicep build-params`.
+
 ## [0.7.1] - 2026-07-27
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Pester guard `tests/Avm-Module-Pinning.Tests.ps1`: every `br/public:avm/...` reference must pin an exact semver, each AVM module must resolve to a single version repo-wide, and `bicepconfig.json` must not define registry aliases.
+- Pester guard `tests/Avm-Module-Pinning.Tests.ps1`: every `br/public:avm/...` reference must pin an exact semver, each AVM module must resolve to a single version repo-wide, and `bicepconfig.json` must not define registry aliases. The suite also asserts that the scan itself matched at least one `.bicep` file and one AVM declaration, so the guard cannot pass vacuously.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Module 4 (Storage): Lab 4.1 storage accounts with conditional encryption and Lab 4.2 Blob Storage.
 - Project foundations: specification, naming/standards documents, security files, README, and course navigation.
 
-[Unreleased]: https://github.com/mbiszczanik/skycraft/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mbiszczanik/skycraft/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/mbiszczanik/skycraft/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/mbiszczanik/skycraft/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mbiszczanik/skycraft/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mbiszczanik/skycraft/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bicep standards rewritten to an **AVM-first** policy (issue #62 v2): Azure Verified Modules consumed directly from `main.bicep` entry points, exact-version pinning with a repo-wide catalogue, canonical tag set (`Project`/`Environment`/`CostCenter`/`Owner`), an explicit-`dependsOn` rule, lab-friction override principle, and a documented Lab 3.1 hand-written-modules exception.
 - Lint workflow now builds every `.bicepparam` file with `az bicep build-params`.
+- Lint workflow now parses every `.ps1`/`.psm1`/`.psd1` with the PowerShell parser before running PSScriptAnalyzer, annotating each syntax error with its file and line. PSScriptAnalyzer's gate counts only `Severity -eq 'Error'` and reports none for a file that cannot be parsed, so a syntax error used to reach CI unnoticed unless a Pester container happened to fail on it.
 
 ## [0.7.1] - 2026-07-27
 

--- a/DESIGN-DECISIONS.md
+++ b/DESIGN-DECISIONS.md
@@ -209,10 +209,11 @@ lab; this section is the architect's view in one place.
 ### 14. Infrastructure-as-Code maturity
 
 - **Lab:** Bicep throughout (no ARM JSON). `main.bicep` orchestrator pattern
-  with reusable modules in `bicep/modules/`. Standardized header block
+  consuming Azure Verified Modules directly (see theme 15); hand-written
+  modules only as documented fallbacks. Standardized header block
   (SUMMARY / DESCRIPTION / EXAMPLE / AUTHOR / VERSION). API versions pinned
-  (`2023-11-01` for Networking, `2022-04-01` for Authorization). PowerShell
-  conventions and Bicep conventions enforced via
+  for raw resources; AVM references pinned by exact module version.
+  PowerShell conventions and Bicep conventions enforced via
   [docs/bicep-standards.md](docs/bicep-standards.md) and
   [docs/powershell-standards.md](docs/powershell-standards.md).
 - **Production gap:** No CI/CD pipeline that lints / validates / `what-if`s
@@ -221,6 +222,24 @@ lab; this section is the architect's view in one place.
 - **Why it matters:** Templates without a pipeline are still
   click-through-with-extra-steps. The lab demonstrates the artifact;
   production needs the workflow.
+
+### 15. AVM-first module strategy
+
+- **Lab:** All Bicep entry points consume [Azure Verified Modules](https://aka.ms/avm)
+  directly from the public registry (`br/public:avm/res/...`), pinned to exact
+  versions catalogued in [docs/bicep-standards.md](docs/bicep-standards.md).
+  Hand-written modules remain only where no `Available` AVM module exists
+  (tags, autoscale settings) — and in Lab 3.1, where writing modules by hand
+  *is* the learning objective.
+- **Production gap:** No private registry mirror of AVM modules, no automated
+  AVM version-update pipeline (Dependabot does not cover Bicep registries),
+  and lab-friction overrides (soft delete disabled on Key Vault and Recovery
+  Services Vault) that a production deployment must never copy.
+- **Why it matters:** This is a deliberate educational stance: the course
+  teaches consuming verified building blocks the way production teams do,
+  not authoring expert-level IaC from scratch. The student reads AVM
+  parameters instead of raw resource properties everywhere except Lab 3.1,
+  which opens the black box once.
 
 ---
 

--- a/docs/bicep-standards.md
+++ b/docs/bicep-standards.md
@@ -430,6 +430,9 @@ output outExampleId string = resExample.id
 
 ### 10.1 BCP120: Cannot Reference `kind`/`sku` from Existing Resources (E001)
 
+> [!NOTE]
+> This gotcha applies to the pre-AVM hand-written pattern (today's Lab 4.1 code and local fallback modules). It will be retired when Lab 4.1 is converted to `avm/res/storage/storage-account` (issue #62 v2, PR 4/6), where `networkAcls` is a module parameter.
+
 **Error**: `BCP120: This expression is being used in an assignment to the "kind" property... which requires a value that can be calculated at the start of the deployment.`
 
 **Root Cause**: When re-declaring a storage account to update its `networkAcls` (firewall), Bicep requires `kind` and `sku` — but these cannot be read from an `existing` resource reference at compile time.

--- a/docs/bicep-standards.md
+++ b/docs/bicep-standards.md
@@ -36,6 +36,9 @@ To ensure stability, consistency, and tool compatibility across the SkyCraft pro
 > [!NOTE]
 > This policy is enforced by `tests/Api-Version-Policy.Tests.ps1` and is the reason the `use-recent-api-versions` linter rule is disabled in [`bicepconfig.json`](#7-linter-configuration-bicepconfigjson).
 
+> [!NOTE]
+> API versions apply to **raw resource declarations only**. AVM module references (`br/public:avm/...`) carry no API version — they are pinned by exact module version instead (see [Section 4.4](#44-avm-version-catalogue)) and enforced by `tests/Avm-Module-Pinning.Tests.ps1`.
+
 ## 3. Naming Conventions (Hungarian Notation)
 
 We use specific prefixes to identify the type of object within Bicep code. This prevents confusion between a parameter, a variable, and the resource itself.
@@ -55,58 +58,118 @@ We use specific prefixes to identify the type of object within Bicep code. This 
 
 For the names of the **deployed Azure resources themselves** (`prod-skycraft-swc-vnet`, etc.), see [azure-reference.md — Naming Conventions](azure-reference.md#1-naming-conventions). That document is the single source of truth for resource naming; do not duplicate the pattern here (rule D004).
 
-## 4. Architecture Pattern
+## 4. Architecture Pattern (AVM-First)
 
-We aim for a modular architecture that separates **Orchestration** from **Implementation**.
+We separate **Orchestration** from **Implementation**, and we implement resources by consuming [Azure Verified Modules (AVM)](https://aka.ms/avm) from the public Bicep registry.
 
 ### 4.1 Orchestrator (`main.bicep`)
 
 - **Scope**: `targetScope = 'subscription'` (usually).
-- **Purpose**: Creates Resource Groups (if needed) and calls Modules.
-- **Content**: Should **not** contain resource definitions directly (except RGs). It should mostly contain `module` blocks.
+- **Purpose**: Creates Resource Groups via `br/public:avm/res/resources/resource-group` and calls resource AVM modules **directly**.
+- **Content**: `module` blocks (plus trivial `existing` lookups). No raw `resource` definitions.
 
-### 4.2 Modules (`modules/*.bicep`)
+### 4.2 Consuming AVM Modules
 
-- **Scope**: Default (Resource Group).
-- **Purpose**: Deploys specific sets of resources (e.g., "Networking", "Security", "Compute").
-- **Best Practice**: Modules should be self-contained and reusable.
+Reference AVM modules directly from the entry point with their **full registry path** and an **exact pinned version**:
+
+```bicep
+module modStorage 'br/public:avm/res/storage/storage-account:<pinned-version>' = {
+  name: 'storage-deployment'
+  scope: resRg
+  params: {
+    name: varStorageAccountName
+    location: parLocation
+    tags: varCommonTags
+  }
+}
+```
+
+Rules:
+
+- **No registry aliases** — do not add `moduleAliases` to `bicepconfig.json`. The full `br/public:avm/res/...` path keeps provenance visible in every file (enforced by `tests/Avm-Module-Pinning.Tests.ps1`).
+- **AVM parameter names are camelCase** without prefixes — that is the module's contract, not ours. Hungarian notation ([Section 3](#3-naming-conventions-hungarian-notation)) applies only to *our* symbols (`par*`, `var*`, `mod*`, `out*`).
+- **Use built-in AVM parameters** instead of separate local modules where they exist: `tags`, `lock`, `diagnosticSettings`, `roleAssignments`.
+- **Network access**: building templates with AVM references requires access to `mcr.microsoft.com` (available on GitHub runners; local builds cache modules under `~/.bicep`).
+
+### 4.3 Local Fallback Modules (`modules/*.bicep`)
+
+Hand-written modules are the **exception**, allowed only when no suitable AVM module exists (missing from the AVM index, or not `Available`). Current fallbacks:
+
+- `Microsoft.Resources/tags` (Lab 1.3) — no AVM module exists.
+- Autoscale settings (Lab 3.4) — `avm/res/insights/autoscale-setting` is only *Proposed*.
+- Trivial `existing` lookups (e.g. the public-IP lookup in Lab 2.3) — stay inline or as a tiny local module.
+- All of Lab 3.1's modules — see [Section 8.2](#82-hand-written-modules-in-lab-31).
+
+Fallback modules must meet the full gold-path standard: header banner, Hungarian notation, `@description` + validation decorators on every parameter, canonical tags, pinned stable API versions.
+
+### 4.4 AVM Version Catalogue
+
+Every AVM reference pins an **exact version** (`x.y.z`), and a given AVM module uses a **single version across the whole repository**. Both rules are enforced by `tests/Avm-Module-Pinning.Tests.ps1`. To upgrade a module, update every reference and this catalogue in the same PR.
+
+| AVM module | Pinned version | Used in |
+| :--- | :--- | :--- |
+| `avm/res/authorization/role-assignment/sub-scope` | `0.1.1` | Lab 1.2 |
+| `avm/res/authorization/policy-assignment/sub-scope` | `0.1.0` | Lab 1.3 |
+
+> [!NOTE]
+> The catalogue grows as labs are converted (issue #62 v2). Each conversion PR appends its modules here.
+
+### 4.5 Lab-Friction Overrides
+
+The labs must stay easy to run, test, and tear down for students. Wherever an AVM default conflicts with that, override it explicitly at the call site with a short comment referencing this section. Known overrides:
+
+- **Key Vault** (`key-vault/vault`): disable soft delete and purge protection, so labs can be re-run and cleaned up without purge waits.
+- **Recovery Services Vault** (`recovery-services/vault`): disable soft delete / immutability settings, so `Remove-LabResource.ps1` can delete the vault.
+
+Further overrides follow the same principle and are decided per lab.
 
 ## 5. Resource Tagging (REQUIRED)
 
 All Azure resources **must** be tagged to comply with governance policies (Lab 1.3).
 
-### Required Tags
+### Required Tags (canonical set)
 
-Every resource must include the following tags:
+Every resource carries **exactly** these four tags — no more, no fewer:
 
 | Tag             | Description              | Example                     |
 | :-------------- | :----------------------- | :-------------------------- |
 | **Project**     | Always set to `SkyCraft` | `Project: 'SkyCraft'`       |
 | **Environment** | Deployment environment   | `Environment: 'Production'` |
 | **CostCenter**  | Cost tracking identifier | `CostCenter: 'MSDN'`        |
+| **Owner**       | Resource owner           | `Owner: 'mbiszczanik'`      |
+
+> [!IMPORTANT]
+> `ManagedBy` and `DeploymentDate` are **not** part of the canonical set. In particular, never tag with a deployment timestamp (`parCurrentDate` pattern) — a value that changes on every run breaks `what-if` idempotency and produces noisy diffs.
 
 ### Implementation Pattern
 
-Define a `varCommonTags` variable and apply it to all resources:
+Define a `varCommonTags` variable and pass it to every AVM module call via its `tags` parameter (and to any raw resource via `tags:`):
 
 ```bicep
+@description('Resource owner tag value')
+param parOwner string = 'mbiszczanik'
+
 var varCommonTags = {
   Project: 'SkyCraft'
-  Environment: parEnvironment  // Pass as parameter
+  Environment: parEnvironment
   CostCenter: 'MSDN'
+  Owner: parOwner
 }
 
-resource resExample 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
-  name: 'example-nsg'
-  location: parLocation
-  tags: varCommonTags  // Apply tags here
-  properties: {
-    // ...
+module modVnet 'br/public:avm/res/network/virtual-network:<pinned-version>' = {
+  name: 'vnet-deployment'
+  scope: resRg
+  params: {
+    name: varVnetName
+    addressPrefixes: [parVnetAddressPrefix]
+    location: parLocation
+    tags: varCommonTags
   }
 }
 ```
 
-> [!IMPORTANT] > **Failure to tag resources will cause deployment failures** due to Azure Policy enforcement.
+> [!IMPORTANT]
+> **Failure to tag resources will cause deployment failures** due to Azure Policy enforcement.
 
 ## 6. Best Practices
 
@@ -171,6 +234,11 @@ resource resExample 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
 
 - **What-if first**: Every deployment must be previewed with `what-if` before the real run. The standard pattern (separate args arrays) is defined in [powershell-standards.md — WhatIf Deployment Pattern](powershell-standards.md#5-best-practices).
 
+### 6.5 Dependencies
+
+- **Never write explicit `dependsOn` when a symbolic reference already exists.** Referencing another resource's or module's property (`modVnet.outputs.outVnetId`) creates the dependency implicitly; a redundant `dependsOn` is dead weight and hides the real data flow.
+- Explicit `dependsOn` is allowed **only** for genuine sequencing that no symbolic reference expresses (e.g. VNet peering ordering) — and must carry a comment explaining why.
+
 ## 7. Linter Configuration (`bicepconfig.json`)
 
 The repository root contains a [`bicepconfig.json`](../bicepconfig.json) that the Bicep CLI and VS Code extension pick up automatically for every `.bicep` file in the repo. It promotes the most important linter rules to `error` severity, so violations **fail the build** instead of being silently ignored.
@@ -198,11 +266,11 @@ These are deliberate decisions where SkyCraft departs from the official Microsof
 - **We do**: `par*`, `var*`, `res*`, `mod*`, `out*` prefixes ([Section 3](#3-naming-conventions-hungarian-notation)).
 - **Why**: AZ-104 learners read templates before they write them. Explicit prefixes make the role of every identifier visible at a glance without IDE hover support (e.g., in lab guides, diffs, and printed material).
 
-### 8.2 No Azure Verified Modules (AVM)
+### 8.2 Hand-Written Modules in Lab 3.1
 
-- **Microsoft says**: Prefer consuming [Azure Verified Modules](https://aka.ms/avm) from the public registry (`br/public:avm/res/...`) instead of hand-writing resource modules.
-- **We do**: Hand-written modules in `bicep/modules/`.
-- **Why**: Writing the resource definitions yourself is the learning objective. AVM hides exactly the properties (subnets, NSG rules, SKUs) that AZ-104 requires you to understand. AVM is introduced as a "what production teams actually use" reference, not as the lab tool.
+- **Microsoft says**: Prefer consuming [Azure Verified Modules](https://aka.ms/avm) from the public registry instead of hand-writing resource modules — which is exactly what the rest of this repository does ([Section 4](#4-architecture-pattern-avm-first)).
+- **We do**: Lab 3.1 (Infrastructure as Code) keeps fully hand-written local modules.
+- **Why**: Writing resource definitions by hand **is** that lab's learning objective. Everywhere else the course teaches what production teams actually do — consume AVM; in Lab 3.1 it teaches what is inside such a module. Lab 3.1 receives the gold-path retrofit (decorators, tags, conventions) but no AVM conversion.
 
 ### 8.3 Pinned Stable API Versions
 
@@ -238,7 +306,15 @@ targetScope = 'subscription'
 *    Parameters    *
 *******************/
 @description('Location for all resources')
+@allowed(['swedencentral', 'northeurope'])
 param parLocation string = 'swedencentral'
+
+@description('Environment tag value')
+@allowed(['Platform', 'Development', 'Production'])
+param parEnvironment string = 'Production'
+
+@description('Resource owner tag value')
+param parOwner string = 'mbiszczanik'
 
 @description('Resource Group Name')
 @minLength(1)
@@ -246,28 +322,54 @@ param parLocation string = 'swedencentral'
 param parResourceGroupName string
 
 /*******************
-*    Resources     *
+*    Variables     *
 *******************/
+var varCommonTags = {
+  Project: 'SkyCraft'
+  Environment: parEnvironment
+  CostCenter: 'MSDN'
+  Owner: parOwner
+}
+
+/*******************
+*     Modules      *
+*******************/
+
+module modResourceGroup 'br/public:avm/res/resources/resource-group:<pinned-version>' = {
+  name: 'rg-deployment'
+  params: {
+    name: parResourceGroupName
+    location: parLocation
+    tags: varCommonTags
+  }
+}
 
 resource resRg 'Microsoft.Resources/resourceGroups@2023-07-01' existing = {
   name: parResourceGroupName
 }
 
-module modExample 'modules/example.bicep' = {
+module modExample 'br/public:avm/res/storage/storage-account:<pinned-version>' = {
   name: 'example-deployment'
   scope: resRg
   params: {
-    parLocation: parLocation
+    name: 'examplename'
+    location: parLocation
+    tags: varCommonTags
   }
+  dependsOn: [
+    modResourceGroup // RG must exist before RG-scoped modules; no symbolic reference available
+  ]
 }
 
 /******************
 *     Outputs     *
 ******************/
-output outExampleId string = modExample.outputs.outExampleId
+output outExampleId string = modExample.outputs.resourceId
 ```
 
-### Module Template (`modules/example.bicep`)
+### Local Fallback Module Template (`modules/example.bicep`)
+
+Use only when no suitable AVM module exists — see [Section 4.3](#43-local-fallback-modules-modulesbicep). Remember to extend `varCommonTags` with `Owner` (as in the orchestrator template above).
 
 ```bicep
 /*=====================================================
@@ -288,6 +390,9 @@ param parLocation string
 @allowed(['Platform', 'Development', 'Production'])
 param parEnvironment string = 'Production'
 
+@description('Resource owner tag value')
+param parOwner string = 'mbiszczanik'
+
 /*******************
 *    Variables     *
 *******************/
@@ -295,6 +400,7 @@ var varCommonTags = {
   Project: 'SkyCraft'
   Environment: parEnvironment
   CostCenter: 'MSDN'
+  Owner: parOwner
 }
 
 var varResourceName = 'example-resource'

--- a/tests/Api-Version-Policy.Tests.ps1
+++ b/tests/Api-Version-Policy.Tests.ps1
@@ -13,6 +13,10 @@
     A sibling regression test guards the specific bleeding-edge versions that were
     previously in the repo so they do not creep back in.
 
+    Scope: raw resource declarations only. AVM registry references
+    ('br/public:avm/...') carry no API version; their pinning policy is
+    enforced by tests/Avm-Module-Pinning.Tests.ps1 instead.
+
 .EXAMPLE
     Invoke-Pester -Path .\tests\Api-Version-Policy.Tests.ps1
 

--- a/tests/Avm-Module-Pinning.Tests.ps1
+++ b/tests/Avm-Module-Pinning.Tests.ps1
@@ -24,8 +24,7 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 $RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
-$BicepFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep' |
-              Where-Object { $_.FullName -match '[/\\]module-\d' }
+$BicepFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep'
 
 # Every AVM registry reference across the repo: br/public:<avm-path>:<version>
 $AvmRefPattern = "'br/public:(avm/[a-z0-9/-]+):([^']+)'"

--- a/tests/Avm-Module-Pinning.Tests.ps1
+++ b/tests/Avm-Module-Pinning.Tests.ps1
@@ -28,7 +28,7 @@ $BicepFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep'
 
 # Every AVM registry reference across the repo from actual module declarations:
 # module <symbolicName> 'br/public:<avm-path>:<version>' = {
-$AvmRefPattern = "(?m)^\s*module\s+\S+\s+'br/public:(avm/[a-z0-9/-]+):([^']+)'"
+$AvmRefPattern = "(?m)^\s*module\s+\S+\s+['`\"]br/public:(avm/[a-z0-9/-]+):([^'`\"]+)['`\"]"
 $AllRefs = foreach ($f in $BicepFiles) {
     $text = Get-Content -Raw -LiteralPath $f.FullName
     foreach ($m in [regex]::Matches($text, $AvmRefPattern)) {

--- a/tests/Avm-Module-Pinning.Tests.ps1
+++ b/tests/Avm-Module-Pinning.Tests.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+    Pester 5 tests: AVM registry references are pinned and consistent repo-wide.
+
+.DESCRIPTION
+    docs/bicep-standards.md (AVM-first policy, issue #62 v2) requires:
+      - every 'br/public:avm/...' reference pins an EXACT semver (x.y.z) —
+        no floating tags, no partial versions
+      - a given AVM module resolves to a SINGLE version across the whole
+        repository (the version catalogue in docs/bicep-standards.md)
+      - no registry aliases in bicepconfig.json — full br/public: paths only
+
+    API-version policy for raw resource declarations lives in
+    tests/Api-Version-Policy.Tests.ps1; AVM references carry no API version
+    and are governed by this file instead.
+
+.EXAMPLE
+    Invoke-Pester -Path .\tests\Avm-Module-Pinning.Tests.ps1
+
+.NOTES
+    Project: SkyCraft
+#>
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+$RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$BicepFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep' |
+              Where-Object { $_.FullName -match '[/\\]module-\d' }
+
+# Every AVM registry reference across the repo: br/public:<avm-path>:<version>
+$AvmRefPattern = "'br/public:(avm/[a-z0-9/-]+):([^']+)'"
+$AllRefs = foreach ($f in $BicepFiles) {
+    $text = Get-Content -Raw -LiteralPath $f.FullName
+    foreach ($m in [regex]::Matches($text, $AvmRefPattern)) {
+        [pscustomobject]@{
+            File    = $f.FullName.Substring($RepoRoot.Length + 1)
+            Module  = $m.Groups[1].Value
+            Version = $m.Groups[2].Value
+        }
+    }
+}
+
+$RefCases = @($AllRefs | ForEach-Object {
+    @{ file = $_.File; module = $_.Module; version = $_.Version }
+})
+
+$ModuleCases = @($AllRefs | Group-Object Module | ForEach-Object {
+    @{
+        module   = $_.Name
+        versions = @($_.Group.Version | Sort-Object -Unique)
+        files    = @($_.Group.File | Sort-Object -Unique)
+    }
+})
+
+Describe 'AVM - every reference is pinned to an exact semver' {
+    It "'<file>' pins '<module>' to an exact x.y.z version (got '<version>')" -ForEach $RefCases {
+        $version | Should -Match '^\d+\.\d+\.\d+$' -Because "AVM references must pin an exact x.y.z version; '$module' in '$file' uses '$version'"
+    }
+}
+
+Describe 'AVM - single version per module repo-wide' {
+    It "'<module>' resolves to exactly one version across the repository" -ForEach $ModuleCases {
+        $versions.Count | Should -Be 1 -Because "module '$module' is referenced with versions [$($versions -join ', ')] in: $($files -join '; ')"
+    }
+}
+
+Describe 'AVM - no registry aliases' {
+    It 'bicepconfig.json defines no moduleAliases' {
+        $config = Get-Content -Raw -LiteralPath (Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..')).Path 'bicepconfig.json') | ConvertFrom-Json
+        $config.PSObject.Properties.Name | Should -Not -Contain 'moduleAliases' -Because 'AVM is consumed via full br/public: paths only'
+    }
+}

--- a/tests/Avm-Module-Pinning.Tests.ps1
+++ b/tests/Avm-Module-Pinning.Tests.ps1
@@ -28,7 +28,7 @@ $BicepFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep'
 
 # Every AVM registry reference across the repo from actual module declarations:
 # module <symbolicName> 'br/public:<avm-path>:<version>' = {
-$AvmRefPattern = "(?m)^\s*module\s+\S+\s+['`\"]br/public:(avm/[a-z0-9/-]+):([^'`\"]+)['`\"]"
+$AvmRefPattern = "(?m)^\s*module\s+\S+\s+'br/public:(avm/[a-z0-9/-]+):([^']+)'"
 $AllRefs = foreach ($f in $BicepFiles) {
     $text = Get-Content -Raw -LiteralPath $f.FullName
     foreach ($m in [regex]::Matches($text, $AvmRefPattern)) {
@@ -51,6 +51,23 @@ $ModuleCases = @($AllRefs | Group-Object Module | ForEach-Object {
         files    = @($_.Group.File | Sort-Object -Unique)
     }
 })
+
+# The guards below are data-driven: an empty scan produces zero test cases and
+# a vacuously green suite. Assert that the scan itself found something.
+$ScanCases = @(@{
+    fileCount = @($BicepFiles).Count
+    refCount  = $RefCases.Count
+})
+
+Describe 'AVM - the scan is not vacuous' {
+    It 'finds at least one .bicep file to scan' -ForEach $ScanCases {
+        $fileCount | Should -BeGreaterThan 0 -Because 'an empty file scan lets every other assertion in this file pass without validating anything'
+    }
+
+    It 'matches at least one AVM module declaration' -ForEach $ScanCases {
+        $refCount | Should -BeGreaterThan 0 -Because "scanned $fileCount .bicep file(s) and matched no 'br/public:avm/...' module declaration; either the AVM-first policy regressed or the scan pattern no longer matches the declaration syntax"
+    }
+}
 
 Describe 'AVM - every reference is pinned to an exact semver' {
     It "'<file>' pins '<module>' to an exact x.y.z version (got '<version>')" -ForEach $RefCases {

--- a/tests/Avm-Module-Pinning.Tests.ps1
+++ b/tests/Avm-Module-Pinning.Tests.ps1
@@ -26,8 +26,9 @@
 $RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $BicepFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.bicep'
 
-# Every AVM registry reference across the repo: br/public:<avm-path>:<version>
-$AvmRefPattern = "'br/public:(avm/[a-z0-9/-]+):([^']+)'"
+# Every AVM registry reference across the repo from actual module declarations:
+# module <symbolicName> 'br/public:<avm-path>:<version>' = {
+$AvmRefPattern = "(?m)^\s*module\s+\S+\s+'br/public:(avm/[a-z0-9/-]+):([^']+)'"
 $AllRefs = foreach ($f in $BicepFiles) {
     $text = Get-Content -Raw -LiteralPath $f.FullName
     foreach ($m in [regex]::Matches($text, $AvmRefPattern)) {


### PR DESCRIPTION
## AVM v2 — PR 0 of 6: Foundations

Foundations for the AVM-first Bicep retrofit (#62, v2 scope). Documentation, CI, and test guards only — **no Bicep template changes**.

### Changes
- `docs/bicep-standards.md` rewritten to an AVM-first policy: direct `br/public:avm/res/...` consumption from entry points, exact-version pinning with a repo-wide catalogue, canonical tags (`Project`/`Environment`/`CostCenter`/`Owner`), explicit-`dependsOn` rule, lab-friction overrides, Lab 3.1 hand-written-modules exception, AVM-first boilerplate.
- New Pester guard `tests/Avm-Module-Pinning.Tests.ps1` (exact semver pinning, single version per module repo-wide, no registry aliases).
- `tests/Api-Version-Policy.Tests.ps1`: scope note — raw resources only; AVM refs governed by the new guard.
- `lint.yml`: builds every `.bicepparam` with `az bicep build-params`.
- `DESIGN-DECISIONS.md`: new cross-cutting theme 15 (AVM-first module strategy); theme 14 updated.
- `CHANGELOG.md`: Unreleased entries; fixed missing v0.7.1 link references.

### Verification
- Full Pester suite green locally (727/727, incl. the new guard, which already validates the existing module-1 AVM references).
- `az bicep build` over all entry points and `az bicep build-params` over all param files — clean.

### Follow-ups
PRs 1–5 convert course modules 1–5 lab by lab (AVM + gold path + docs + live verification). Release v0.8.0 lands with the final PR.

Closes nothing yet — #62 stays open until PR 5/6.