### PR TITLE
fix: correct guest-user checks in Lab 1.1 and 1.2 validation scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Module 1 local Bicep modules `rg-role-assignment.bicep`, `locks.bicep`, and `policies.bicep`, superseded by the AVM modules above; `tags.bicep` is retained as the documented fallback for `Microsoft.Resources/tags`.
 
+### Fixed
+
+- Lab 1.1 `Test-Lab.ps1` looked for the guest user by the wrong e-mail (`istormrage@...`); it now checks `illidan@externalcompany.com`, the address `New-LabUser.ps1` invites.
+- Lab 1.2 `Test-Lab.ps1` could never find the External Partner assignment: guest sign-in names are rewritten to `<alias>_<domain>#EXT#@<tenant>`, so the `illidan@` match is now `illidan[@_]`.
+
 ## [0.7.1] - 2026-07-27
 
 ### Removed

--- a/module-1-identities-governance/1.1-entra-users-groups/scripts/Test-Lab.ps1
+++ b/module-1-identities-governance/1.1-entra-users-groups/scripts/Test-Lab.ps1
@@ -8,7 +8,7 @@
     (Admins, Developers, Testers) exist and have the correct members assigned.
 
 .EXAMPLE
-    .\Test-Lab-1.1.ps1
+    .\Test-Lab.ps1
     Runs the validation suite.
 
 .NOTES
@@ -59,7 +59,7 @@ $expectedUsers = @(
     "malfurion.stormrage@$domain"
     "khadgar.archmage@$domain"
     "chromie.timewalker@$domain"
-    "istormrage@externalcompany.com" # Guest user
+    "illidan@externalcompany.com" # Guest user (invited by New-LabUser.ps1)
 )
 
 # Validate Users

--- a/module-1-identities-governance/1.2-rbac/scripts/Test-Lab.ps1
+++ b/module-1-identities-governance/1.2-rbac/scripts/Test-Lab.ps1
@@ -10,7 +10,7 @@
     - Illidan -> Reader (platform-rg)
 
 .EXAMPLE
-    .\Test-Lab-1.2.ps1
+    .\Test-Lab.ps1
     Runs validation.
 
 .NOTES
@@ -61,7 +61,7 @@ $checks = @(
     @{ Name="Developers Group";  Principal="SkyCraft-Developers";  Role="Contributor"; Scope="/subscriptions/$subId/resourceGroups/dev-skycraft-swc-rg" }
     @{ Name="Testers Group (Dev)"; Principal="SkyCraft-Testers";   Role="Reader";      Scope="/subscriptions/$subId/resourceGroups/dev-skycraft-swc-rg" }
     @{ Name="Testers Group (Prod)"; Principal="SkyCraft-Testers";  Role="Reader";      Scope="/subscriptions/$subId/resourceGroups/prod-skycraft-swc-rg" }
-    @{ Name="External Partner";  Principal="illidan@";             Role="Reader";      Scope="/subscriptions/$subId/resourceGroups/platform-skycraft-swc-rg" }
+    @{ Name="External Partner";  Principal="illidan[@_]";         Role="Reader";      Scope="/subscriptions/$subId/resourceGroups/platform-skycraft-swc-rg" }
 )
 
 foreach ($check in $checks) {
@@ -76,7 +76,8 @@ foreach ($check in $checks) {
         }
         
         # Filter for role and principal
-        # Using match for UPN because domain might vary, or DisplayName for groups
+        # Using match for UPN because domain might vary, or DisplayName for groups.
+        # Guest sign-in names are rewritten to <alias>_<domain>#EXT#@<tenant>, hence the [@_] pattern for Illidan.
         $found = $assignments | Where-Object { 
             ($_.RoleDefinitionName -eq $check.Role) -and 
             ( ($_.SignInName -match $check.Principal) -or ($_.DisplayName -eq $check.Principal) )


### PR DESCRIPTION
Two pre-existing defects in the Module 1 validation scripts, surfaced by the first full live run of Labs 1.1–1.3 with an Entra-capable identity (2026-08-27, after #85).

## Fixes

- **Lab 1.1 `Test-Lab.ps1`** — looked for the guest by `istormrage@externalcompany.com`; `New-LabUser.ps1` invites `illidan@externalcompany.com`. The check now uses the invited address, so the guest assertion can pass.
- **Lab 1.2 `Test-Lab.ps1`** — the External Partner check matched `illidan@` against `SignInName`, but Azure rewrites guest sign-in names to `<alias>_<domain>#EXT#@<tenant>` (`illidan_externalcompany.com#EXT#@…`), so the Reader assignment on `platform-skycraft-swc-rg` was reported missing even when present. Pattern is now `illidan[@_]` (matches both the guest form and a plain UPN; no overlap with the group names).
- Both scripts: stale `.EXAMPLE` file names (`Test-Lab-1.x.ps1` → `Test-Lab.ps1`).

## Verification

- Live evidence from the 2026-08-27 run: Lab 1.1 reported `[FAIL] User missing: istormrage@externalcompany.com` while the guest existed; Lab 1.2 reported `[FAIL] Expected Assignment 'Reader' for 'illidan@' NOT found` while `Get-AzRoleAssignment` showed the assignment with `SignInName = illidan_externalcompany.com#EXT#@euvic.onmicrosoft.com`.
- New pattern checked against that observed `SignInName` (match), the plain UPN form (match) and the group display names (no match).
- PSScriptAnalyzer (project settings): 0 errors, 0 warnings on both scripts. Pester: 730/730.
- Lab resources were cleaned up after the run, so the scripts were not re-executed live; the change is confined to the two lookups above.

Related: #62 (Module 1 live cycle), #85.