### PR TITLE
fix: make Lab 3.2 deploy script non-interactive safe (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lab 3.2 `Deploy-Bicep.ps1` takes a `-Force` switch and no longer confirms the deployment by reading stdin (#103). Run non-interactively, the old `Read-Host` prompt read EOF, printed `Deployment cancelled.` and exited **0**, so an orchestrating chain recorded the skipped VM deployment as a success and only failed two labs later. The confirmation is now a host prompt defaulting to No instead of a stdin read: `-Force` deploys without asking, and a declined confirmation - or a session with no console to prompt on - exits **2** having deployed nothing.
+
 ## [0.8.0] - 2026-08-29
 
 ### Added

--- a/module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1
@@ -24,6 +24,11 @@
 .PARAMETER WhatIf
     Run deployment in what-if mode (dry run)
 
+.PARAMETER Force
+    Skip the confirmation prompt so the script can run non-interactively
+    (lab-cycle orchestration, CI). Without it, a session that cannot prompt
+    aborts with exit code 2 instead of silently deploying nothing.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment dev
 
@@ -33,11 +38,18 @@
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment dev -EncryptionStrategy AzureDiskEncryption -WhatIf
 
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -Environment dev -Force
+    Deploys without prompting - the form to use from an automated caller.
+
 .NOTES
     Project: SkyCraft
     Lab: 3.2 - Virtual Machines
     Author: Marcin Biszczanik
     Date: 2026-01-11
+    Exit codes: 0 = success (or -WhatIf preview), 1 = prerequisite or deployment
+                failure, 2 = deployment declined or no console to confirm on
+                (nothing was deployed).
 #>
 
 #Requires -Version 7.0
@@ -63,7 +75,10 @@ param(
     [string]$SshKeyPath = "$HOME\.ssh\skycraft-dev.pub",
 
     [Parameter()]
-    [switch]$WhatIf
+    [switch]$WhatIf,
+
+    [Parameter()]
+    [switch]$Force
 )
 
 $ErrorActionPreference = 'Stop'
@@ -135,11 +150,30 @@ Write-Host "  Template:             $templatePath"
 Write-Host "  Deployment Name:      $deploymentName"
 
 # Confirm deployment
-if (-not $WhatIf) {
-    $confirm = Read-Host "`nProceed with deployment? (y/N)"
-    if ($confirm -ne 'y') {
+# The prompt must never be answered by a stream: a confirmation read from stdin
+# returns an empty answer at EOF, which used to cancel the deployment and still
+# exit 0 - an automated caller then treated the skipped deployment as a success.
+# Automation passes -Force; every other outcome (declined, or no console to ask
+# on) exits 2 and deploys nothing.
+if (-not $WhatIf -and -not $Force) {
+    $choices = [System.Management.Automation.Host.ChoiceDescription[]]@(
+        [System.Management.Automation.Host.ChoiceDescription]::new('&Yes', 'Deploy the resources listed above.')
+        [System.Management.Automation.Host.ChoiceDescription]::new('&No', 'Cancel. Nothing is deployed.')
+    )
+
+    try {
+        $answer = $Host.UI.PromptForChoice('Lab 3.2 - Virtual Machines', "`nProceed with deployment?", $choices, 1)
+    }
+    catch {
+        Write-Host "`n[ABORTED] Cannot ask for confirmation: this session has no interactive console." -ForegroundColor Red
+        Write-Host "  Re-run with -Force to deploy non-interactively. Deployment cancelled." -ForegroundColor Gray
+        Write-Verbose "PromptForChoice failed: $($_.Exception.Message)"
+        exit 2
+    }
+
+    if ($answer -ne 0) {
         Write-Host "Deployment cancelled." -ForegroundColor Yellow
-        exit 0
+        exit 2
     }
 }
 

--- a/tests/Script-Standards.Tests.ps1
+++ b/tests/Script-Standards.Tests.ps1
@@ -36,6 +36,21 @@ $RemoveCases = $AllScripts | Where-Object { $_.Name -like 'Remove-*.ps1' } | For
     @{ file = $_.FullName.Substring($RepoRoot.Length + 1); path = $_.FullName }
 }
 
+$DeployPromptCases = $AllScripts |
+                     Where-Object { $_.Name -like 'Deploy-*.ps1' -and
+                                    (Get-Content -Raw -LiteralPath $_.FullName) -match 'Proceed with deployment' } |
+                     ForEach-Object {
+                         @{ file = $_.FullName.Substring($RepoRoot.Length + 1); path = $_.FullName }
+                     }
+
+# Regression guard for issue #103 (Lab 3.2 deployment silently skipped by a non-interactive caller)
+$Lab32DeployCase = @(
+    @{
+        file = 'module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1'
+        path = (Join-Path $RepoRoot 'module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1')
+    }
+)
+
 Describe 'SkyCraft PowerShell - script standards' {
 
     It "'<file>' sets `$ErrorActionPreference = 'Stop'" -ForEach $ScriptCases {
@@ -64,5 +79,32 @@ Describe 'SkyCraft PowerShell - destructive scripts use ShouldProcess' {
     It "'<file>' contains no manual Read-Host prompt" -ForEach $RemoveCases {
         $content = Get-Content -Raw -LiteralPath $path
         $content | Should -Not -Match 'Read-Host'
+    }
+}
+
+Describe 'SkyCraft PowerShell - deployment scripts stay automatable' {
+
+    It "'<file>' declares a -Force switch so the confirmation can be skipped" -ForEach $DeployPromptCases {
+        $content = Get-Content -Raw -LiteralPath $path
+        $content | Should -Match '\[switch\]\$Force'
+    }
+}
+
+Describe 'SkyCraft PowerShell - Lab 3.2 deployment cannot be silently skipped' {
+
+    It "'<file>' documents the -Force switch in its comment-based help" -ForEach $Lab32DeployCase {
+        $content = Get-Content -Raw -LiteralPath $path
+        $content | Should -Match '\.PARAMETER Force'
+    }
+
+    It "'<file>' contains no manual Read-Host prompt" -ForEach $Lab32DeployCase {
+        $content = Get-Content -Raw -LiteralPath $path
+        $content | Should -Not -Match 'Read-Host'
+    }
+
+    It "'<file>' exits non-zero when the deployment is declined" -ForEach $Lab32DeployCase {
+        $content = Get-Content -Raw -LiteralPath $path
+        $content | Should -Not -Match 'Deployment cancelled\.[^\r\n]*[\r\n]+\s*exit 0'
+        $content | Should -Match 'Deployment cancelled\.[^\r\n]*[\r\n]+\s*exit [1-9]'
     }
 }


### PR DESCRIPTION
Closes #103.

## Problem

`module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1` confirmed the deployment with `Read-Host`. Run without a terminal the prompt read EOF, `$confirm` was empty, the script printed `Deployment cancelled.` and exited **0** — so the v0.8.0 cycle recorded the skipped dev VM deployment as a success and only failed two labs later, when Lab 5.2 had no VM to protect.

## Change

- **`-Force`** switch, matching `5.1`/`5.2`/`5.3 Deploy-Bicep.ps1`, skips the confirmation.
- The confirmation is now `$Host.UI.PromptForChoice` (default **No**) instead of a stdin read. A prompt-first design was chosen over a `[Console]::IsInputRedirected` pre-check because the VS Code PowerShell Integrated Console also reports stdin as redirected, and a pre-check would refuse to prompt a learner who can perfectly well answer.
- **Exit 2** on every non-deploying outcome: confirmation declined, or no console to ask on (the prompt throws). An automated caller can no longer read a skipped deployment as a completed one.
- `.PARAMETER Force`, an `-Force` example, and the exit-code table added to the comment-based help.

`-WhatIf` behaviour is unchanged, and it still short-circuits the confirmation.

## Tests

`tests/Script-Standards.Tests.ps1` gains:

- a repo-wide rule — every `Deploy-*.ps1` that asks *Proceed with deployment?* must declare `[switch]$Force` (3.2, 5.1, 5.2, 5.3);
- a #103 regression guard on Lab 3.2 — no `Read-Host`, `-Force` documented in the CBH, and the cancellation branch must not `exit 0`.

All three fail on the pre-fix script.

## Verification

Run against the real script with every Azure entry point stubbed (`New-AzSubscriptionDeployment` is an **alias**, so it has to be shadowed with `Set-Alias`, not a function):

| scenario | result |
|---|---|
| `-Force`, stdin closed | deploys, **exit 0** |
| no `-Force`, stdin closed | nothing deployed, **exit 2** |
| no `-Force`, `-NonInteractive`, stdin closed | nothing deployed, **exit 2** |
| no `-Force`, `n` piped | `Deployment cancelled.`, **exit 2** |
| no `-Force`, `y` piped | deploys, **exit 0** (the #73 workaround still works, it is simply no longer needed) |
| `-WhatIf` | unchanged, **exit 0** |

`Invoke-Pester ./tests` on the committed tree: **710 passed, 0 failed**. PSScriptAnalyzer: 0 errors (the one `PSUseBOMForUnicodeEncodedFile` warning predates this change).

## Follow-up

Whatever ends up orchestrating the lab cycle (#73) should call this script with `-Force` rather than feeding `y` on stdin.