### PR TITLE
feat: give every lab deploy script a real what-if (#74)

### DIFF
--- a/docs/dry-run-harness.md
+++ b/docs/dry-run-harness.md
@@ -103,12 +103,18 @@ Two things to know before copying anything below:
 - **`az deployment sub what-if` is read-only.** It previews the change set and deploys nothing.
 - **Labs are cumulative.** A what-if for a later lab reports the resources an earlier lab was supposed to create as missing if that lab was never deployed. Work through a module in order.
 
-Labs 3.1, 3.2, 5.1, 5.2 and 5.3 have a `-WhatIf` switch on their own `Deploy-Bicep.ps1`. Prefer it over the raw `az` command wherever the checked-in parameter file cannot stand on its own:
+Every lab's `Deploy-Bicep.ps1` now takes a `-WhatIf` switch (issue #74) that runs
+`Get-AzSubscriptionDeploymentWhatIfResult` with the same arguments the real deployment would use,
+prints the ARM change set and exits 0 without deploying. **Prefer it over a raw `az` command**: it
+previews exactly what the script would send, including the values the script resolves at run time,
+which a raw command against the checked-in parameter file cannot always reproduce:
 
 - **Module 5 (5.1, 5.2, 5.3)**: the `.bicepparam` files carry well-formed **placeholder** resource IDs under the zero subscription GUID, purely so `az bicep build-params` can validate them offline against `@minLength(1)`. The deploy scripts resolve the real IDs from Azure at run time, so a raw what-if for these labs previews against the placeholders and is not meaningful.
 - **Lab 3.2**: `parSshPublicKey` is read from the `SKYCRAFT_SSH_PUBLIC_KEY` environment variable and defaults to empty. `Deploy-Bicep.ps1` supplies the key directly.
+- **Lab 4.4**: `parClientIp` is auto-detected by the script; a raw what-if previews an empty firewall rule instead.
 
-Labs 3.1, and every lab in Modules 1, 2 and 4, have self-contained parameter files, so the raw `az deployment sub what-if` form below is accurate for them.
+The raw `az deployment sub what-if` form is still listed where the script does not cover a template:
+Lab 1.2's `role-assignments.bicep` and Lab 3.3's resource-group-scope `acr.bicep` bootstrap.
 
 All commands are written to be run from the repository root.
 
@@ -120,8 +126,7 @@ All commands are written to be run from the repository root.
 .\module-1-identities-governance\1.1-entra-users-groups\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 1.2 - RBAC
-az deployment sub what-if --location swedencentral `
-    --parameters module-1-identities-governance/1.2-rbac/bicep/parameters/resource-groups.bicepparam
+.\module-1-identities-governance\1.2-rbac\scripts\Deploy-Bicep.ps1 -WhatIf
 # role-assignments.bicep has no parameter file: its four principal IDs are Entra object IDs
 # that only exist once Lab 1.1 has run, so pass them explicitly.
 az deployment sub what-if --location swedencentral `
@@ -132,8 +137,7 @@ az deployment sub what-if --location swedencentral `
 .\module-1-identities-governance\1.2-rbac\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 1.3 - Governance
-az deployment sub what-if --location swedencentral `
-    --parameters module-1-identities-governance/1.3-governance/bicep/parameters/main.bicepparam
+.\module-1-identities-governance\1.3-governance\scripts\Deploy-Bicep.ps1 -WhatIf
 .\module-1-identities-governance\1.3-governance\scripts\Test-Lab.ps1
 .\module-1-identities-governance\1.3-governance\scripts\Remove-LabResource.ps1 -WhatIf
 ```
@@ -142,20 +146,17 @@ az deployment sub what-if --location swedencentral `
 
 ```powershell
 # Lab 2.1 - Virtual networks
-az deployment sub what-if --location swedencentral `
-    --parameters module-2-networking/2.1-virtual-networks/bicep/parameters/main.bicepparam
+.\module-2-networking\2.1-virtual-networks\scripts\Deploy-Bicep.ps1 -WhatIf
 .\module-2-networking\2.1-virtual-networks\scripts\Test-Lab.ps1
 .\module-2-networking\2.1-virtual-networks\scripts\Remove-LabResource.ps1 -WhatIf
 
-# Lab 2.2 - Secure access
-az deployment sub what-if --location swedencentral `
-    --parameters module-2-networking/2.2-secure-access/bicep/parameters/main.bicepparam
+# Lab 2.2 - Secure access (-WhatIf skips the Bastion prompt and previews with Bastion off)
+.\module-2-networking\2.2-secure-access\scripts\Deploy-Bicep.ps1 -WhatIf
 .\module-2-networking\2.2-secure-access\scripts\Test-Lab.ps1
 .\module-2-networking\2.2-secure-access\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 2.3 - Name resolution
-az deployment sub what-if --location swedencentral `
-    --parameters module-2-networking/2.3-name-resolution/bicep/parameters/main.bicepparam
+.\module-2-networking\2.3-name-resolution\scripts\Deploy-Bicep.ps1 -WhatIf
 .\module-2-networking\2.3-name-resolution\scripts\Test-Lab.ps1
 .\module-2-networking\2.3-name-resolution\scripts\Remove-LabResource.ps1 -WhatIf
 ```
@@ -164,10 +165,8 @@ az deployment sub what-if --location swedencentral `
 
 ```powershell
 # Lab 3.1 - Infrastructure as code (dev and prod parameter sets)
-az deployment sub what-if --location swedencentral `
-    --parameters module-3-compute/3.1-infrastructure-as-code/bicep/parameters/dev.bicepparam
-az deployment sub what-if --location swedencentral `
-    --parameters module-3-compute/3.1-infrastructure-as-code/bicep/parameters/prod.bicepparam
+.\module-3-compute\3.1-infrastructure-as-code\scripts\Deploy-Bicep.ps1 -Environment dev -WhatIf
+.\module-3-compute\3.1-infrastructure-as-code\scripts\Deploy-Bicep.ps1 -Environment prod -WhatIf
 .\module-3-compute\3.1-infrastructure-as-code\scripts\Test-Lab.ps1
 .\module-3-compute\3.1-infrastructure-as-code\scripts\Remove-LabResource.ps1 -WhatIf
 
@@ -176,9 +175,8 @@ az deployment sub what-if --location swedencentral `
 .\module-3-compute\3.2-virtual-machines\scripts\Test-Lab.ps1
 .\module-3-compute\3.2-virtual-machines\scripts\Remove-LabResource.ps1 -WhatIf
 
-# Lab 3.3 - Containers
-az deployment sub what-if --location swedencentral `
-    --parameters module-3-compute/3.3-containers/bicep/parameters/main.bicepparam
+# Lab 3.3 - Containers (-WhatIf previews main.bicep only; the ACR bootstrap is skipped, not simulated)
+.\module-3-compute\3.3-containers\scripts\Deploy-Bicep.ps1 -WhatIf
 # acr.bicep is the resource-group-scope bootstrap that Deploy-Bicep.ps1 runs first:
 az deployment group what-if --resource-group dev-skycraft-swc-rg `
     --template-file module-3-compute/3.3-containers/bicep/acr.bicep
@@ -186,8 +184,7 @@ az deployment group what-if --resource-group dev-skycraft-swc-rg `
 .\module-3-compute\3.3-containers\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 3.4 - App Service
-az deployment sub what-if --location swedencentral `
-    --parameters module-3-compute/3.4-app-service/bicep/parameters/main.bicepparam
+.\module-3-compute\3.4-app-service\scripts\Deploy-Bicep.ps1 -WhatIf
 .\module-3-compute\3.4-app-service\scripts\Test-Lab.ps1
 .\module-3-compute\3.4-app-service\scripts\Remove-LabResource.ps1 -WhatIf
 ```
@@ -198,33 +195,29 @@ Module 4 labs are cumulative forward and must be previewed in order — every la
 
 ```powershell
 # Lab 4.1 - Storage accounts
-az deployment sub what-if --location swedencentral `
-    --parameters module-4-storage/4.1-storage-accounts/bicep/parameters/main.bicepparam
+.\module-4-storage\4.1-storage-accounts\scripts\Deploy-Bicep.ps1 -All -WhatIf
 .\module-4-storage\4.1-storage-accounts\scripts\Test-Lab.ps1
 .\module-4-storage\4.1-storage-accounts\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 4.2 - Blob storage
-az deployment sub what-if --location swedencentral `
-    --parameters module-4-storage/4.2-blob-storage/bicep/parameters/main.bicepparam
+.\module-4-storage\4.2-blob-storage\scripts\Deploy-Bicep.ps1 -WhatIf
 .\module-4-storage\4.2-blob-storage\scripts\Test-Lab.ps1
 .\module-4-storage\4.2-blob-storage\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 4.3 - Azure Files
-az deployment sub what-if --location swedencentral `
-    --parameters module-4-storage/4.3-azure-files/bicep/parameters/main.bicepparam
+.\module-4-storage\4.3-azure-files\scripts\Deploy-Bicep.ps1 -Environment prod -WhatIf
 .\module-4-storage\4.3-azure-files\scripts\Test-Lab.ps1
 .\module-4-storage\4.3-azure-files\scripts\Remove-LabResource.ps1 -WhatIf
 
 # Lab 4.4 - Storage security
-az deployment sub what-if --location swedencentral `
-    --parameters module-4-storage/4.4-storage-security/bicep/parameters/main.bicepparam
+.\module-4-storage\4.4-storage-security\scripts\Deploy-Bicep.ps1 -Environment prod -WhatIf
 .\module-4-storage\4.4-storage-security\scripts\Test-Lab.ps1
 .\module-4-storage\4.4-storage-security\scripts\Remove-LabResource.ps1 -WhatIf
 ```
 
 ### 4.5 Module 5 — Monitoring and Maintenance
 
-Every Module 5 lab resolves resource IDs from Azure at run time, so use the deploy script's own `-WhatIf` rather than a raw `az` command.
+Every Module 5 lab resolves resource IDs from Azure at run time, so the deploy script's own `-WhatIf` is the only meaningful preview here - a raw `az` command would preview the placeholder IDs.
 
 ```powershell
 # Lab 5.1 - Azure Monitor (-OpsEmail is mandatory)

--- a/docs/powershell-standards.md
+++ b/docs/powershell-standards.md
@@ -190,19 +190,44 @@ if ($script:cleanupFailures -gt 0) {
   $account = az account show --output json 2>$null | ConvertFrom-Json
   ```
 
-- **WhatIf Deployment Pattern**: Build separate args arrays for what-if vs real deployment rather than mutating indices. This avoids brittle index-based overwrites and makes intent clear:
+- **WhatIf Deployment Pattern**: Every `Deploy-Bicep.ps1` declares a `[switch]$WhatIf` and branches on it **around one shared splat**, so the preview is built from exactly the arguments the deployment would use. Build the hashtable once, then pick the cmdlet:
 
   ```powershell
-  # ❌ WRONG — index mutation is fragile
-  $deployArgs[2] = 'what-if'
-
-  # ✅ CORRECT — build two clean arrays
-  if ($WhatIf) {
-      $deployArgs = @('deployment', 'sub', 'what-if') + $commonParams
-  } else {
-      $deployArgs = @('deployment', 'sub', 'create') + $commonParams + @('--output', 'json')
+  # ✅ CORRECT — one splat, two cmdlets
+  $deployParams = @{
+      Name         = $deploymentName
+      Location     = $Location
+      TemplateFile = $templateFile
+      ErrorAction  = 'Stop'
   }
+
+  if ($WhatIf) {
+      Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+      Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+      Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+      exit 0
+  }
+
+  $deployment = New-AzSubscriptionDeployment @deployParams
   ```
+
+  Template parameters go in the same hashtable, either as `TemplateParameterFile` /
+  `TemplateParameterObject` or as the cmdlet's dynamic `par*` parameters — both bind on the
+  what-if cmdlet too.
+
+  Two things this rules out, both of which shipped before issue #74:
+
+  ```powershell
+  # ❌ WRONG — a message is not a preview. Exits 0 having checked nothing.
+  if ($WhatIf) { Write-Host "What-if mode: run 'az deployment sub what-if' by hand."; exit 0 }
+
+  # ❌ WRONG — SupportsShouldProcess makes -WhatIf skip the call, not preview it.
+  if ($PSCmdlet.ShouldProcess('resources', 'Deploy')) { New-AzSubscriptionDeployment @deployParams }
+  ```
+
+  `tests/Script-Standards.Tests.ps1` enforces this: it parses each deploy script, finds the body of
+  its `if ($WhatIf)` branch, and asserts that the branch calls `Get-AzSubscriptionDeploymentWhatIfResult`
+  and deploys nothing.
 
 ## 6. Static Analysis & Testing
 

--- a/module-1-identities-governance/1.2-rbac/scripts/Deploy-Bicep.ps1
+++ b/module-1-identities-governance/1.2-rbac/scripts/Deploy-Bicep.ps1
@@ -9,9 +9,16 @@
 .PARAMETER Location
     Azure region for deployment. Default: swedencentral.
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1
     Deploys to Sweden Central.
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the resource group deployment without creating anything.
 
 .NOTES
     Project: SkyCraft
@@ -24,7 +31,9 @@
 [CmdletBinding()]
 param(
     [ValidateSet('swedencentral', 'northeurope')]
-    [string]$Location = 'swedencentral'
+    [string]$Location = 'swedencentral',
+
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -62,11 +71,21 @@ Write-Host "  Location: $Location" -ForegroundColor Gray
 Write-Host "  DeploymentName: $deploymentName" -ForegroundColor Gray
 
 try {
-    New-AzSubscriptionDeployment `
-        -Name $deploymentName `
-        -Location $Location `
-        -TemplateFile $templateFile `
-        -ErrorAction Stop | Out-Null
+    $deployParams = @{
+        Name         = $deploymentName
+        Location     = $Location
+        TemplateFile = $templateFile
+        ErrorAction  = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    New-AzSubscriptionDeployment @deployParams | Out-Null
     
     Write-Host "  -> [SUCCESS] Resource Groups deployed successfully." -ForegroundColor Green
     

--- a/module-1-identities-governance/1.3-governance/scripts/Deploy-Bicep.ps1
+++ b/module-1-identities-governance/1.3-governance/scripts/Deploy-Bicep.ps1
@@ -12,8 +12,15 @@
 .PARAMETER Owner
     Value for the canonical Owner tag. Default: mbiszczanik.
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Owner "mbiszczanik"
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the governance deployment without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -29,7 +36,9 @@ param(
     [string]$Location = 'swedencentral',
 
     [ValidateNotNullOrEmpty()]
-    [string]$Owner = 'mbiszczanik'
+    [string]$Owner = 'mbiszczanik',
+
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -72,12 +81,22 @@ try {
         parOwner    = $Owner
     }
 
-    $deployment = New-AzSubscriptionDeployment `
-        -Name $deploymentName `
-        -Location $Location `
-        -TemplateFile $templateFile `
-        -TemplateParameterObject $params `
-        -Verbose
+    $deployParams = @{
+        Name                    = $deploymentName
+        Location                = $Location
+        TemplateFile            = $templateFile
+        TemplateParameterObject = $params
+        ErrorAction             = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams -Verbose
 
     if ($deployment.ProvisioningState -eq 'Succeeded') {
         Write-Host "  -> [SUCCESS] Governance deployment completed." -ForegroundColor Green

--- a/module-2-networking/2.1-virtual-networks/scripts/Deploy-Bicep.ps1
+++ b/module-2-networking/2.1-virtual-networks/scripts/Deploy-Bicep.ps1
@@ -21,9 +21,16 @@
 .PARAMETER PlatformResourceGroup
     The platform resource group name. Default: 'platform-skycraft-swc-rg'
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1
     Deploys to default resource groups in Sweden Central.
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the hub-and-spoke deployment without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -51,7 +58,10 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
-    [string]$PlatformResourceGroup = 'platform-skycraft-swc-rg'
+    [string]$PlatformResourceGroup = 'platform-skycraft-swc-rg',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -90,12 +100,22 @@ try {
         parResourceGroupNamePlatform = $PlatformResourceGroup
     }
 
-    $deployment = New-AzSubscriptionDeployment `
-        -Name $deploymentName `
-        -Location $Location `
-        -TemplateFile $mainBicep `
-        -TemplateParameterObject $params `
-        -Verbose
+    $deployParams = @{
+        Name                    = $deploymentName
+        Location                = $Location
+        TemplateFile            = $mainBicep
+        TemplateParameterObject = $params
+        ErrorAction             = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams -Verbose
 
     if ($deployment.ProvisioningState -eq 'Succeeded') {
         Write-Host "`n[SUCCESS] Deployment completed successfully!" -ForegroundColor Green

--- a/module-2-networking/2.2-secure-access/scripts/Deploy-Bicep.ps1
+++ b/module-2-networking/2.2-secure-access/scripts/Deploy-Bicep.ps1
@@ -20,9 +20,18 @@
 .PARAMETER PlatformResourceGroup
     The platform resource group name. Default: 'platform-skycraft-swc-rg'
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+    The Bastion prompt is skipped in this mode and the preview is built with Bastion off -
+    the same answer an unattended cycle gives, and the one that costs nothing.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1
     Deploys to default resource groups in Sweden Central.
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the ASG/NSG deployment (Bastion off) without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -46,7 +55,10 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
-    [string]$PlatformResourceGroup = 'platform-skycraft-swc-rg'
+    [string]$PlatformResourceGroup = 'platform-skycraft-swc-rg',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -75,12 +87,20 @@ if (-not (Test-Path $mainBicep)) {
 
 Write-Host "`nDeploying Lab 2.2 resources..." -ForegroundColor Cyan
 
-# Ask user about Bastion deployment
-Write-Host "`n[OPTIONAL] Azure Bastion provides secure RDP/SSH access without public IPs." -ForegroundColor Yellow
-Write-Host "Cost: ~$140/month | Deployment time: ~15 minutes" -ForegroundColor Gray
-$deployBastion = Read-Host "Do you want to deploy Azure Bastion? (y/N)"
+# Ask user about Bastion deployment. A what-if run answers the prompt for the caller:
+# it changes nothing, so blocking a preview on stdin would only break non-interactive
+# callers, and 'no' is the answer that keeps the ~$140/month meter off.
+if ($WhatIf) {
+    Write-Host "`n[OPTIONAL] Azure Bastion prompt skipped in what-if mode - previewing with Bastion off." -ForegroundColor Gray
+    $shouldDeployBastion = $false
+}
+else {
+    Write-Host "`n[OPTIONAL] Azure Bastion provides secure RDP/SSH access without public IPs." -ForegroundColor Yellow
+    Write-Host "Cost: ~$140/month | Deployment time: ~15 minutes" -ForegroundColor Gray
+    $deployBastion = Read-Host "Do you want to deploy Azure Bastion? (y/N)"
 
-$shouldDeployBastion = ($deployBastion -eq 'y' -or $deployBastion -eq 'Y')
+    $shouldDeployBastion = ($deployBastion -eq 'y' -or $deployBastion -eq 'Y')
+}
 
 if ($shouldDeployBastion) {
     Write-Host "  -> Bastion will be deployed" -ForegroundColor Green
@@ -99,12 +119,22 @@ try {
         parDeployBastion             = $shouldDeployBastion
     }
 
-    $deployment = New-AzSubscriptionDeployment `
-        -Name $deploymentName `
-        -Location $Location `
-        -TemplateFile $mainBicep `
-        -TemplateParameterObject $params `
-        -Verbose
+    $deployParams = @{
+        Name                    = $deploymentName
+        Location                = $Location
+        TemplateFile            = $mainBicep
+        TemplateParameterObject = $params
+        ErrorAction             = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams -Verbose
 
     if ($deployment.ProvisioningState -eq 'Succeeded') {
         Write-Host "`n[SUCCESS] Deployment completed successfully!" -ForegroundColor Green

--- a/module-2-networking/2.3-name-resolution/scripts/Deploy-Bicep.ps1
+++ b/module-2-networking/2.3-name-resolution/scripts/Deploy-Bicep.ps1
@@ -15,9 +15,16 @@
     Path to the Bicep template to deploy. Defaults to '..\bicep\main.bicep' (relative to
     this script's folder).
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1
     Deploys the default main.bicep to Sweden Central using the current Az context.
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the DNS and load balancer deployment without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -39,7 +46,10 @@ param(
     # the only script in the repository that had to be run from its own scripts/ folder (#75).
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
-    [string]$TemplateFile = (Join-Path $PSScriptRoot '..\bicep\main.bicep')
+    [string]$TemplateFile = (Join-Path $PSScriptRoot '..\bicep\main.bicep'),
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -58,11 +68,21 @@ if (-not (Test-Path $TemplateFile)) {
 Write-Host "Starting deployment: $deploymentName..." -ForegroundColor Yellow
 
 try {
-    $deployment = New-AzDeployment `
-        -Name $deploymentName `
-        -Location $Location `
-        -TemplateFile $TemplateFile `
-        -Verbose
+    $deployParams = @{
+        Name         = $deploymentName
+        Location     = $Location
+        TemplateFile = $TemplateFile
+        ErrorAction  = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzDeployment @deployParams -Verbose
 
     if ($deployment.ProvisioningState -ne 'Succeeded') {
         Write-Host "`n[FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red

--- a/module-3-compute/3.1-infrastructure-as-code/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.1-infrastructure-as-code/scripts/Deploy-Bicep.ps1
@@ -13,11 +13,15 @@
     Target environment (dev, prod). Default: 'dev'
 
 .PARAMETER WhatIf
-    If specified, runs What-If analysis instead of deploying.
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
 
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment dev
     Deploys the Development environment.
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -Environment dev -WhatIf
+    Previews the Development deployment without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -69,20 +73,22 @@ Write-Host "Params:   $paramPath" -ForegroundColor Gray
 
 try {
     
-    $commonArgs = @{
+    $deployParams = @{
         Name                  = $deploymentName
         Location              = $Location
         TemplateFile          = $bicepPath
         TemplateParameterFile = $paramPath
+        ErrorAction           = 'Stop'
     }
 
     if ($WhatIf) {
-        Write-Host "Running What-If Analysis..." -ForegroundColor Yellow
-        New-AzSubscriptionDeployment @commonArgs -WhatIf
+        Write-Host "Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`nWhat-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
     }
     else {
         Write-Host "Deploying..." -ForegroundColor Yellow
-        $dep = New-AzSubscriptionDeployment @commonArgs
+        $dep = New-AzSubscriptionDeployment @deployParams
         
         if ($dep.ProvisioningState -eq 'Succeeded') {
             Write-Host "`n[SUCCESS] Deployment complete!" -ForegroundColor Green

--- a/module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.2-virtual-machines/scripts/Deploy-Bicep.ps1
@@ -22,7 +22,7 @@
     Path to SSH public key file. Default: $HOME\.ssh\skycraft-dev.pub
 
 .PARAMETER WhatIf
-    Run deployment in what-if mode (dry run)
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
 
 .PARAMETER Force
     Skip the confirmation prompt so the script can run non-interactively
@@ -200,7 +200,9 @@ try {
     }
 
     if ($WhatIf) {
-        Write-Host "  What-if mode: run 'az deployment sub what-if' for ARM preview. Skipping deployment." -ForegroundColor Cyan
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
         exit 0
     } else {
         $deployment = New-AzSubscriptionDeployment @deployParams

--- a/module-3-compute/3.3-containers/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.3-containers/scripts/Deploy-Bicep.ps1
@@ -22,9 +22,18 @@
 .PARAMETER Environment
     The environment tag. Default: 'dev'
 
+.PARAMETER WhatIf
+    Previews the main.bicep deployment with the ARM what-if API and exits. Nothing is created
+    or changed - which also means the Phase 1 bootstrap (resource group, ACR, image import) is
+    skipped rather than simulated, so the preview needs those prerequisites to already exist.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1
     Deploys to default resource groups.
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the ACI/ACA orchestrator without bootstrapping or deploying anything.
 
 .NOTES
     Project: SkyCraft
@@ -48,7 +57,10 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('dev', 'prod', 'platform')]
-    [string]$Environment = 'dev'
+    [string]$Environment = 'dev',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -69,11 +81,35 @@ $bicepPath = Join-Path $PSScriptRoot "..\bicep"
 $mainBicep = Join-Path $bicepPath "main.bicep"
 $acrBicep = Join-Path $bicepPath "acr.bicep"
 $deploymentName = "Lab-3.3-Containers"
+$acrName = "devskycraftswcacr01" # Should match main.bicep default or param
 
 if (-not (Test-Path $mainBicep)) {
     Write-Host "[ERROR] Bicep file not found: $mainBicep" -ForegroundColor Red
     $Host.SetShouldExit(1)
     exit 1
+}
+
+$deployParams = @{
+    Name                    = $deploymentName
+    Location                = $Location
+    TemplateFile            = $mainBicep
+    TemplateParameterObject = @{
+        parLocation          = $Location
+        parResourceGroupName = $ResourceGroupName
+        parEnvironment       = $Environment
+        parAcrName           = $acrName
+    }
+    ErrorAction             = 'Stop'
+}
+
+# What-if runs before Phase 1: bootstrapping the registry and importing the image are real
+# changes, so a preview must not perform them. The preview covers main.bicep only.
+if ($WhatIf) {
+    Write-Host "`nRunning in what-if mode (dry run)..." -ForegroundColor Cyan
+    Write-Host "  Phase 1 (resource group, ACR bootstrap, image import) is skipped, not simulated." -ForegroundColor Gray
+    Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+    Write-Host "`nWhat-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+    exit 0
 }
 
 # Ensure RG exists (needed for module deployment / bootstrapping)
@@ -94,7 +130,6 @@ try {
 # PHASE 1: BOOTSTRAP ACR & IMAGE
 # ==============================================================================
 Write-Host "`n=== Phase 1: Bootstrapping Prerequisites ===" -ForegroundColor Cyan
-$acrName = "devskycraftswcacr01" # Should match main.bicep default or param
 
 # Check if we need to bootstrap image
 $repoExists = $false
@@ -155,19 +190,7 @@ if ($acrWasBootstrapped) {
 Write-Host "`n=== Phase 2: Orchestrated Deployment (main.bicep) ===" -ForegroundColor Cyan
 
 try {
-    $params = @{
-        parLocation        = $Location
-        parResourceGroupName = $ResourceGroupName
-        parEnvironment     = $Environment
-        parAcrName         = $acrName
-    }
-
-    $deployment = New-AzSubscriptionDeployment `
-        -Name $deploymentName `
-        -Location $Location `
-        -TemplateFile $mainBicep `
-        -TemplateParameterObject $params `
-        -Verbose
+    $deployment = New-AzSubscriptionDeployment @deployParams -Verbose
 
     if ($deployment.ProvisioningState -eq 'Succeeded') {
         Write-Host "`n[SUCCESS] Deployment completed successfully!" -ForegroundColor Green

--- a/module-3-compute/3.4-app-service/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.4-app-service/scripts/Deploy-Bicep.ps1
@@ -12,8 +12,15 @@
 .PARAMETER Environment
     Target environment (dev, prod). Default: dev.
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment dev
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -Environment dev -WhatIf
+    Previews the App Service deployment without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -31,7 +38,10 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('dev', 'prod')]
-    [string]$Environment = 'dev'
+    [string]$Environment = 'dev',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -58,12 +68,22 @@ try {
         parVnetName          = "$Environment-skycraft-swc-vnet"
     }
 
-    $deployment = New-AzSubscriptionDeployment `
-        -Name $DeploymentName `
-        -Location $Location `
-        -TemplateFile $BicepFile `
-        -TemplateParameterObject $params `
-        -ErrorAction Stop
+    $deployParams = @{
+        Name                    = $DeploymentName
+        Location                = $Location
+        TemplateFile            = $BicepFile
+        TemplateParameterObject = $params
+        ErrorAction             = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams
 
     if ($deployment.ProvisioningState -ne 'Succeeded') {
         Write-Host "[FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red

--- a/module-4-storage/4.1-storage-accounts/scripts/Deploy-Bicep.ps1
+++ b/module-4-storage/4.1-storage-accounts/scripts/Deploy-Bicep.ps1
@@ -22,7 +22,7 @@
     Cannot be changed after storage account creation.
 
 .PARAMETER WhatIf
-    Preview changes without deploying.
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
 
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment dev
@@ -34,7 +34,7 @@
 
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment prod -WhatIf
-    Previews production deployment without making changes.
+    Previews the production deployment with an ARM diff, without making changes.
 
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment prod -InfraEncryption
@@ -50,7 +50,7 @@
 #Requires -Version 7.0
 #Requires -Modules Az.Accounts, Az.Resources, Az.Storage
 
-[CmdletBinding(SupportsShouldProcess)]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
     [ValidateSet('dev', 'prod', 'platform')]
@@ -64,7 +64,10 @@ param(
     [string]$Location = 'swedencentral',
 
     [Parameter(Mandatory = $false)]
-    [switch]$InfraEncryption
+    [switch]$InfraEncryption,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -169,47 +172,56 @@ Write-Host "  Soft Delete: Enabled (7 days)"
 Write-Host ""
 Write-Host "--- Deploying Bicep Template ---" -ForegroundColor Yellow
 
+$deployParams = @{
+    Name                    = $deploymentName
+    Location                = $Location
+    TemplateFile            = $templateFile
+    TemplateParameterObject = $deploymentParams
+    ErrorAction             = 'Stop'
+}
+
 try {
-    if ($PSCmdlet.ShouldProcess("Storage accounts", "Deploy")) {
-        $deployment = New-AzSubscriptionDeployment `
-            -Name $deploymentName `
-            -Location $Location `
-            -TemplateFile $templateFile `
-            -TemplateParameterObject $deploymentParams `
-            -ErrorAction Stop
-
+    if ($WhatIf) {
+        Write-Host "Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
         Write-Host ""
-        Write-Host "=== Deployment Complete ===" -ForegroundColor Cyan
-        Write-Host ""
-        Write-Host "--- Deployment Outputs ---" -ForegroundColor Yellow
-        
-        if ($deployment.Outputs.outDeployedEnvironments) {
-            $envs = $deployment.Outputs.outDeployedEnvironments.Value
-            Write-Host "  Deployed Environments: $($envs -join ', ')" -ForegroundColor Green
-        }
-
-        if ($All -or $Environment -eq 'platform') {
-            if ($deployment.Outputs.outPlatformStorageAccountName.Value -ne 'not-deployed') {
-                Write-Host "  Platform Storage: $($deployment.Outputs.outPlatformStorageAccountName.Value)" -ForegroundColor Green
-            }
-        }
-        
-        if ($All -or $Environment -eq 'dev') {
-            if ($deployment.Outputs.outDevStorageAccountName.Value -ne 'not-deployed') {
-                Write-Host "  Dev Storage: $($deployment.Outputs.outDevStorageAccountName.Value)" -ForegroundColor Green
-            }
-        }
-        
-        if ($All -or $Environment -eq 'prod') {
-            if ($deployment.Outputs.outProdStorageAccountName.Value -ne 'not-deployed') {
-                Write-Host "  Prod Storage: $($deployment.Outputs.outProdStorageAccountName.Value)" -ForegroundColor Green
-            }
-        }
-
-        Write-Host ""
-        Write-Host "Deployment Name: $deploymentName" -ForegroundColor Gray
-        Write-Host "Provisioning State: $($deployment.ProvisioningState)" -ForegroundColor Green
+        Write-Host "What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
     }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams
+
+    Write-Host ""
+    Write-Host "=== Deployment Complete ===" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "--- Deployment Outputs ---" -ForegroundColor Yellow
+    
+    if ($deployment.Outputs.outDeployedEnvironments) {
+        $envs = $deployment.Outputs.outDeployedEnvironments.Value
+        Write-Host "  Deployed Environments: $($envs -join ', ')" -ForegroundColor Green
+    }
+
+    if ($All -or $Environment -eq 'platform') {
+        if ($deployment.Outputs.outPlatformStorageAccountName.Value -ne 'not-deployed') {
+            Write-Host "  Platform Storage: $($deployment.Outputs.outPlatformStorageAccountName.Value)" -ForegroundColor Green
+        }
+    }
+    
+    if ($All -or $Environment -eq 'dev') {
+        if ($deployment.Outputs.outDevStorageAccountName.Value -ne 'not-deployed') {
+            Write-Host "  Dev Storage: $($deployment.Outputs.outDevStorageAccountName.Value)" -ForegroundColor Green
+        }
+    }
+    
+    if ($All -or $Environment -eq 'prod') {
+        if ($deployment.Outputs.outProdStorageAccountName.Value -ne 'not-deployed') {
+            Write-Host "  Prod Storage: $($deployment.Outputs.outProdStorageAccountName.Value)" -ForegroundColor Green
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Deployment Name: $deploymentName" -ForegroundColor Gray
+    Write-Host "Provisioning State: $($deployment.ProvisioningState)" -ForegroundColor Green
 }
 catch {
     Write-Host ""

--- a/module-4-storage/4.2-blob-storage/scripts/Deploy-Bicep.ps1
+++ b/module-4-storage/4.2-blob-storage/scripts/Deploy-Bicep.ps1
@@ -9,8 +9,15 @@
 .PARAMETER Location
     Azure region for deployment. Default: swedencentral
 
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
+
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Location "swedencentral"
+
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -WhatIf
+    Previews the blob storage deployment without changing anything.
 
 .NOTES
     Project: SkyCraft
@@ -24,7 +31,9 @@
 [CmdletBinding()]
 param(
     [ValidateSet('swedencentral', 'northeurope')]
-    [string]$Location = 'swedencentral'
+    [string]$Location = 'swedencentral',
+
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -48,12 +57,22 @@ if (-not (Test-Path $TemplateFile)) {
 try {
     Write-Host "Deploying to Subscription scope..." -ForegroundColor Yellow
     
-    $deployment = New-AzSubscriptionDeployment `
-        -Name "lab-4.2-deploy-$(Get-Date -Format 'yyyyMMdd-HHmm')" `
-        -Location $Location `
-        -TemplateFile $TemplateFile `
-        -TemplateParameterObject @{ parLocation = $Location } `
-        -WarningAction SilentlyContinue
+    $deployParams = @{
+        Name                    = "lab-4.2-deploy-$(Get-Date -Format 'yyyyMMdd-HHmm')"
+        Location                = $Location
+        TemplateFile            = $TemplateFile
+        TemplateParameterObject = @{ parLocation = $Location }
+        ErrorAction             = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams -WarningAction SilentlyContinue
 
     if ($deployment.ProvisioningState -ne 'Succeeded') {
         Write-Host "[FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red

--- a/module-4-storage/4.3-azure-files/scripts/Deploy-Bicep.ps1
+++ b/module-4-storage/4.3-azure-files/scripts/Deploy-Bicep.ps1
@@ -8,8 +8,13 @@
     Azure region for deployment. Default: swedencentral.
 .PARAMETER Environment
     Target environment (prod, dev, platform). Default: prod.
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment prod
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -Environment prod -WhatIf
+    Previews the Azure Files deployment without changing anything.
 .NOTES
     Project: SkyCraft
     Author: SkyCraft
@@ -27,7 +32,10 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('prod', 'dev', 'platform')]
-    [string]$Environment = 'prod'
+    [string]$Environment = 'prod',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,13 +52,23 @@ if (-not $context) {
 try {
     Write-Host "Deploying main.bicep to subscription level..." -ForegroundColor Yellow
     
-    $deployment = New-AzSubscriptionDeployment `
-        -Name "lab-4.3-deploy-$(Get-Date -Format 'yyyyMMdd-HHmm')" `
-        -Location $Location `
-        -TemplateFile (Join-Path $PSScriptRoot "..\bicep\main.bicep") `
-        -parLocation $Location `
-        -parEnvironment $Environment `
-        -ErrorAction Stop
+    $deployParams = @{
+        Name           = "lab-4.3-deploy-$(Get-Date -Format 'yyyyMMdd-HHmm')"
+        Location       = $Location
+        TemplateFile   = (Join-Path $PSScriptRoot "..\bicep\main.bicep")
+        parLocation    = $Location
+        parEnvironment = $Environment
+        ErrorAction    = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams
 
     if ($deployment.ProvisioningState -ne 'Succeeded') {
         Write-Host "`n [FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red

--- a/module-4-storage/4.4-storage-security/scripts/Deploy-Bicep.ps1
+++ b/module-4-storage/4.4-storage-security/scripts/Deploy-Bicep.ps1
@@ -12,8 +12,13 @@
     the storage firewall.
 .PARAMETER ClientIp
     Your client IP to allow through the firewall. Auto-detected if omitted.
+.PARAMETER WhatIf
+    Previews the deployment with the ARM what-if API and exits. Nothing is created or changed.
 .EXAMPLE
     .\Deploy-Bicep.ps1 -Environment prod
+.EXAMPLE
+    .\Deploy-Bicep.ps1 -Environment prod -WhatIf
+    Previews the storage firewall deployment without changing anything.
 .NOTES
     Project: SkyCraft
     Author: SkyCraft
@@ -34,7 +39,10 @@ param(
     [string]$Environment = 'prod',
 
     [Parameter(Mandatory = $false)]
-    [string]$ClientIp = ''
+    [string]$ClientIp = '',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -64,14 +72,24 @@ if ([string]::IsNullOrWhiteSpace($ClientIp)) {
 try {
     Write-Host "Deploying main.bicep to subscription level..." -ForegroundColor Yellow
 
-    $deployment = New-AzSubscriptionDeployment `
-        -Name "lab-4.4-deploy-$(Get-Date -Format 'yyyyMMdd-HHmm')" `
-        -Location $Location `
-        -TemplateFile (Join-Path $PSScriptRoot "..\bicep\main.bicep") `
-        -parLocation $Location `
-        -parEnvironment $Environment `
-        -parClientIp $ClientIp `
-        -ErrorAction Stop
+    $deployParams = @{
+        Name           = "lab-4.4-deploy-$(Get-Date -Format 'yyyyMMdd-HHmm')"
+        Location       = $Location
+        TemplateFile   = (Join-Path $PSScriptRoot "..\bicep\main.bicep")
+        parLocation    = $Location
+        parEnvironment = $Environment
+        parClientIp    = $ClientIp
+        ErrorAction    = 'Stop'
+    }
+
+    if ($WhatIf) {
+        Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
+        Get-AzSubscriptionDeploymentWhatIfResult @deployParams
+        Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
+        exit 0
+    }
+
+    $deployment = New-AzSubscriptionDeployment @deployParams
 
     if ($deployment.ProvisioningState -ne 'Succeeded') {
         Write-Host "`n [FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red

--- a/tests/Script-Standards.Tests.ps1
+++ b/tests/Script-Standards.Tests.ps1
@@ -39,6 +39,57 @@ $RemoveCases = $AllScripts | Where-Object { $_.Name -like 'Remove-*.ps1' } | For
     @{ file = $_.FullName.Substring($RepoRoot.Length + 1); path = $_.FullName }
 }
 
+# Every command name the script actually invokes - comments and strings excluded.
+function Get-InvokedCommandName {
+    param([string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+
+    $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+        ForEach-Object { $_.GetCommandName() } |
+        Where-Object { $_ }
+}
+
+# Every `if ($WhatIf) { ... }` branch body in the script, concatenated, or $null when the
+# script has none. Parsed rather than regex-matched: Lab 3.2's fake what-if printed a message
+# and exited, and only looking inside the branch distinguishes that from one that really calls
+# the ARM API. All branches, not the first: Lab 2.2 guards its Bastion prompt with one branch
+# and previews the deployment in another.
+function Get-WhatIfBranchBody {
+    param([string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+
+    $bodies = foreach ($if in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.IfStatementAst] }, $true)) {
+        # Clauses[0].Item1 is the condition, Item2 the body. The ElseClause is deliberately
+        # excluded - that is where the real deployment lives.
+        $condition = $if.Clauses[0].Item1.Extent.Text.Trim()
+        if ($condition -eq '$WhatIf') { $if.Clauses[0].Item2.Extent.Text }
+    }
+
+    if ($bodies) { return ($bodies -join "`n") }
+    return $null
+}
+
+# Anything a function above derives is resolved here, at discovery time: a function declared
+# in the container body is not in scope inside an It block.
+$RemoveCases = $RemoveCases | ForEach-Object {
+    @{ file = $_.file; path = $_.path; commands = @(Get-InvokedCommandName -Path $_.path) }
+}
+
+# Every lab deploy script, for the what-if contract of issue #74.
+$DeployBicepCases = $AllScripts | Where-Object { $_.Name -eq 'Deploy-Bicep.ps1' } | ForEach-Object {
+    @{
+        file       = $_.FullName.Substring($RepoRoot.Length + 1)
+        path       = $_.FullName
+        whatIfBody = Get-WhatIfBranchBody -Path $_.FullName
+    }
+}
+
 $DeployPromptCases = $AllScripts |
                      Where-Object { $_.Name -like 'Deploy-*.ps1' -and
                                     (Get-Content -Raw -LiteralPath $_.FullName) -match 'Proceed with deployment' } |
@@ -96,8 +147,9 @@ Describe 'SkyCraft PowerShell - destructive scripts use ShouldProcess' {
     }
 
     It "'<file>' contains no manual Read-Host prompt" -ForEach $RemoveCases {
-        $content = Get-Content -Raw -LiteralPath $path
-        $content | Should -Not -Match 'Read-Host'
+        # Commands, not raw text: tools/Remove-LabCycle.ps1 documents in its own help that it
+        # contains no Read-Host, and a raw match reads that sentence as a prompt.
+        $commands | Should -Not -Contain 'Read-Host'
     }
 }
 
@@ -106,6 +158,34 @@ Describe 'SkyCraft PowerShell - deployment scripts stay automatable' {
     It "'<file>' declares a -Force switch so the confirmation can be skipped" -ForEach $DeployPromptCases {
         $content = Get-Content -Raw -LiteralPath $path
         $content | Should -Match '\[switch\]\$Force'
+    }
+}
+
+Describe 'SkyCraft PowerShell - deploy scripts preview with a real what-if' {
+
+    # docs/bicep-standards.md 6.4: every deployment must be previewable with what-if. Before
+    # issue #74 ten of the sixteen deploy scripts had no what-if at all and Lab 3.2's was a
+    # print-and-exit stub, so -WhatIf reported success having previewed nothing.
+
+    It "'<file>' declares a -WhatIf switch" -ForEach $DeployBicepCases {
+        $content = Get-Content -Raw -LiteralPath $path
+        $content | Should -Match '\[switch\]\$WhatIf'
+    }
+
+    It "'<file>' documents -WhatIf in its comment-based help" -ForEach $DeployBicepCases {
+        $content = Get-Content -Raw -LiteralPath $path
+        $content | Should -Match '\.PARAMETER WhatIf'
+        $content | Should -Match '(?m)^\s+\.\\Deploy-Bicep\.ps1.*-WhatIf'
+    }
+
+    It "'<file>' calls the ARM what-if API inside its -WhatIf branch" -ForEach $DeployBicepCases {
+        $whatIfBody | Should -Not -BeNullOrEmpty -Because 'the script must branch on its own $WhatIf switch'
+        $whatIfBody | Should -Match 'Get-AzSubscriptionDeploymentWhatIfResult' -Because 'a what-if that prints a message and exits previews nothing (#74)'
+    }
+
+    It "'<file>' deploys nothing from its -WhatIf branch" -ForEach $DeployBicepCases {
+        $whatIfBody | Should -Not -Match 'New-Az(Subscription)?Deployment'
+        $whatIfBody | Should -Not -Match 'New-AzResourceGroupDeployment'
     }
 }
 


### PR DESCRIPTION
Closes #74.

## Problem

`docs/bicep-standards.md` §6.4 requires a what-if preview before every deployment. Ten of the sixteen `Deploy-Bicep.ps1` scripts had no `-WhatIf` at all, and **two of the six that appeared to have one previewed nothing**:

| Lab | Symptom |
|---|---|
| **3.2** | Printed `What-if mode: run 'az deployment sub what-if' for ARM preview. Skipping deployment.` and exited 0 without calling any API. |
| **4.1** | *Not listed in the issue.* Documented `.PARAMETER WhatIf` and an example, but declared no switch — `[CmdletBinding(SupportsShouldProcess)]` made `-WhatIf` a common parameter, so `ShouldProcess` returned false, the deployment was skipped and the script exited 0. Indistinguishable from a passing preview, and unlike 3.2 it prints nothing to give itself away. |

## Change

Every script now branches on its own `[switch]$WhatIf` around **one shared splat**, so the preview is built from exactly the arguments the deployment would send:

```powershell
if ($WhatIf) {
    Write-Host "  Running in what-if mode (dry run)..." -ForegroundColor Cyan
    Get-AzSubscriptionDeploymentWhatIfResult @deployParams
    Write-Host "`n  What-if completed. Review the changes above - nothing was deployed." -ForegroundColor Cyan
    exit 0
}

$deployment = New-AzSubscriptionDeployment @deployParams
```

This is the pattern labs 5.1–5.3 already used. It binds for both `-TemplateParameterFile` (3.1) and `-TemplateParameterObject` / the cmdlet's dynamic `par*` parameters. Lab 3.1 moves off `New-AzSubscriptionDeployment -WhatIf` onto the house cmdlet; lab 4.1 drops `SupportsShouldProcess`, which `docs/powershell-standards.md` §5 reserves for destructive `Remove-Lab*` scripts.

Two labs needed more than a splat swap:

- **2.2** asked about Azure Bastion through an unconditional `Read-Host`, which would have blocked any non-interactive `-WhatIf` on stdin. The prompt is skipped in what-if mode and the preview built with Bastion off — the answer the unattended cycle already gives it via `StdinAnswers`, and the one that starts no hourly meter. **The deploy path is untouched**, so that workaround still applies unchanged.
- **3.3**'s what-if branch is hoisted above Phase 1. Bootstrapping the ACR and importing the image are real changes, so the preview covers `main.bicep` only and says which step it skipped rather than pretending to simulate it.

## Regression guard

`tests/Script-Standards.Tests.ps1` parses each deploy script, extracts the body of its `if ($WhatIf)` clause — the `else` branch deliberately excluded, since that is where the real deployment lives — and asserts the branch calls the what-if API and deploys nothing. A regex over the whole file would have passed 3.2's stub. Every clause is collected rather than the first, because 2.2 now guards its Bastion prompt with one branch and previews with another. **64 new assertions.**

The same file carried an unrelated false positive that this fixes: the "no manual `Read-Host` prompt" check failed `tools/Remove-LabCycle.ps1` on the sentence in its own help stating that it contains none. The check now matches command names from the AST, for the same reason `Exit-Code-Propagation.Tests.ps1` parses instead of grepping.

## Docs

- `docs/powershell-standards.md` §5 described the what-if pattern as `az` CLI argument arrays, which no deploy script uses. It now documents the cmdlet splat and both broken shapes this PR removes.
- `docs/dry-run-harness.md` §4 claimed only 3.1, 3.2 and module 5 had `-WhatIf` and gave raw `az` commands for the rest. Those now call each lab's own script, keeping the raw form only where no script covers the template (1.2's `role-assignments.bicep`, 3.3's `acr.bicep` bootstrap).

## Verification

- All 16 scripts parse; `tools/Invoke-DryRun.ps1 -Check Parse,Analyzer` passes with **0 analyzer errors** (17 warnings, all pre-existing BOM/unused-var findings in untouched files).
- Pester: the 64 new assertions pass. Five failures remain in the suite, all pre-existing and in `tools/` — confirmed by running the same tests against a clean `main` worktree, which fails **six** (this PR fixes the sixth). They are `Invoke-LabCycle.ps1` / `Remove-LabCycle.ps1` placing `.NOTES` past line 60, and three unguarded non-zero exits in `Invoke-LabScript.ps1`. Left alone — each needs its own call on whether to fix the script or relax the test.
- **Not verified against Azure.** A live `-WhatIf` needs `Connect-AzAccount` and a subscription. The splat keys were checked instead against `Get-AzSubscriptionDeploymentWhatIfResult`'s parameter set (Az.Resources 7.4.0).
