### PR TITLE
feat: exit non-zero when a deployment is not Succeeded (#75)

### DIFF
--- a/docs/powershell-standards.md
+++ b/docs/powershell-standards.md
@@ -126,6 +126,17 @@ Scripts interacting with Azure **must** use `try...catch` blocks to handle API f
 3. Use `-ErrorAction SilentlyContinue` if manually checking existence.
 4. Use `-ErrorAction Stop` when a failure should trigger the `catch` block for retries or termination.
 5. Signal failure to the caller with `$Host.SetShouldExit(<code>)` immediately before every non-zero `exit <code>`. PowerShell 7 discards `exit <code>` from a script run as `pwsh -File` when that script declares `#Requires -Modules` for a module it has to auto-import - every `Az.*` module qualifies. The `exit` still unwinds the script, but the host never applies the code, so the process exits `0` and a failed run looks clean to the automated lab cycle. Keep the `exit` as well, so execution still stops. `exit 0` needs no guard. Enforced by [`tests/Exit-Code-Propagation.Tests.ps1`](../tests/Exit-Code-Propagation.Tests.ps1) (issue #104).
+6. Gate every deployment on its result. `New-Az*Deployment` does not throw for every unhappy ending - a deployment whose resources fail to provision returns an object with `ProvisioningState` set to `Failed` or `Canceled` and the pipeline carries on. Assign the result to a variable and end the script with a non-zero `exit` when it is not `Succeeded`; a deployment piped to `Out-Null` cannot be checked at all. Enforced by [`tests/Deployment-State-Gating.Tests.ps1`](../tests/Deployment-State-Gating.Tests.ps1) (issue #75).
+
+```powershell
+$deployment = New-AzSubscriptionDeployment @deployParams
+
+if ($deployment.ProvisioningState -ne 'Succeeded') {
+    Write-Host "[FAILED] Deployment finished with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+    $Host.SetShouldExit(1)
+    exit 1
+}
+```
 
 ```powershell
 $ErrorActionPreference = 'Stop'

--- a/module-1-identities-governance/1.2-rbac/scripts/Deploy-Bicep.ps1
+++ b/module-1-identities-governance/1.2-rbac/scripts/Deploy-Bicep.ps1
@@ -85,8 +85,14 @@ try {
         exit 0
     }
 
-    New-AzSubscriptionDeployment @deployParams | Out-Null
-    
+    $deployment = New-AzSubscriptionDeployment @deployParams
+
+    if ($deployment.ProvisioningState -ne 'Succeeded') {
+        Write-Host "  -> [FAILED] Deployment finished with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+        $Host.SetShouldExit(1)
+        exit 1
+    }
+
     Write-Host "  -> [SUCCESS] Resource Groups deployed successfully." -ForegroundColor Green
     
     # Verify RGs

--- a/module-2-networking/2.2-secure-access/scripts/Deploy-Bicep.ps1
+++ b/module-2-networking/2.2-secure-access/scripts/Deploy-Bicep.ps1
@@ -143,6 +143,8 @@ try {
     }
     else {
         Write-Host "`n[FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+        $Host.SetShouldExit(1)
+        exit 1
     }
 }
 catch {

--- a/module-3-compute/3.1-infrastructure-as-code/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.1-infrastructure-as-code/scripts/Deploy-Bicep.ps1
@@ -96,6 +96,8 @@ try {
         }
         else {
             Write-Host "`n[FAILED] State: $($dep.ProvisioningState)" -ForegroundColor Red
+            $Host.SetShouldExit(1)
+            exit 1
         }
     }
 }

--- a/module-3-compute/3.3-containers/scripts/Deploy-Bicep.ps1
+++ b/module-3-compute/3.3-containers/scripts/Deploy-Bicep.ps1
@@ -149,12 +149,18 @@ if (-not $repoExists) {
         $acrWasBootstrapped = $true    # only a brand-new registry needs the DNS wait
         Write-Host "Deploying ACR (Bootstrap)..." -ForegroundColor Yellow
         try {
-            New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName `
+            $acrDeployment = New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName `
                 -TemplateFile $acrBicep `
                 -parLocation $Location `
                 -parEnvironment $Environment `
                 -parAcrName $acrName `
-                -ErrorAction Stop | Out-Null
+                -ErrorAction Stop
+
+            if ($acrDeployment.ProvisioningState -ne 'Succeeded') {
+                Write-Host "[ERROR] ACR Bootstrap finished with state: $($acrDeployment.ProvisioningState)" -ForegroundColor Red
+                $Host.SetShouldExit(1)
+                exit 1
+            }
         } catch {
             Write-Host "[ERROR] ACR Bootstrap Failed: $_" -ForegroundColor Red
             $Host.SetShouldExit(1)
@@ -199,7 +205,8 @@ try {
     }
     else {
         Write-Host "`n[FAILED] Deployment failed with state: $($deployment.ProvisioningState)" -ForegroundColor Red
-        # Error handling logic omitted for brevity, similar to template
+        $Host.SetShouldExit(1)
+        exit 1
     }
 }
 catch {

--- a/module-4-storage/4.1-storage-accounts/scripts/Deploy-Bicep.ps1
+++ b/module-4-storage/4.1-storage-accounts/scripts/Deploy-Bicep.ps1
@@ -191,6 +191,13 @@ try {
 
     $deployment = New-AzSubscriptionDeployment @deployParams
 
+    if ($deployment.ProvisioningState -ne 'Succeeded') {
+        Write-Host ""
+        Write-Host "[FAILED] Deployment finished with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+        $Host.SetShouldExit(1)
+        exit 1
+    }
+
     Write-Host ""
     Write-Host "=== Deployment Complete ===" -ForegroundColor Cyan
     Write-Host ""

--- a/module-5-monitoring-maintenance/5.1-azure-monitor/scripts/Deploy-Bicep.ps1
+++ b/module-5-monitoring-maintenance/5.1-azure-monitor/scripts/Deploy-Bicep.ps1
@@ -201,6 +201,12 @@ else {
             }
         }
     }
+
+    if ($deployment.ProvisioningState -ne 'Succeeded') {
+        Write-Host "`n  [FAILED] Deployment finished with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+        $Host.SetShouldExit(1)
+        exit 1
+    }
 }
 
 # ── [5/6] Create DCR association ──────────────────────────────────────────

--- a/module-5-monitoring-maintenance/5.2-business-continuity/scripts/Deploy-Bicep.ps1
+++ b/module-5-monitoring-maintenance/5.2-business-continuity/scripts/Deploy-Bicep.ps1
@@ -163,6 +163,12 @@ if ($WhatIf) {
     $result
     Write-Host "`n  What-if completed. Review changes above." -ForegroundColor Cyan
 } else {
+    if ($deployment.ProvisioningState -ne 'Succeeded') {
+        Write-Host "`n  [FAILED] Deployment finished with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+        $Host.SetShouldExit(1)
+        exit 1
+    }
+
     Write-Host "  ✓ Vaults deployed successfully!" -ForegroundColor Green
     $rsvId = $deployment.Outputs['outRsvId'].Value
     $bvPrincipalId = $deployment.Outputs['outBvPrincipalId'].Value

--- a/module-5-monitoring-maintenance/5.3-network-monitoring/scripts/Deploy-Bicep.ps1
+++ b/module-5-monitoring-maintenance/5.3-network-monitoring/scripts/Deploy-Bicep.ps1
@@ -240,6 +240,12 @@ if ($WhatIf) {
     $result
     Write-Host "`n  What-if completed. Review changes above." -ForegroundColor Cyan
 } else {
+    if ($deployment.ProvisioningState -ne 'Succeeded') {
+        Write-Host "`n  [FAILED] Deployment finished with state: $($deployment.ProvisioningState)" -ForegroundColor Red
+        $Host.SetShouldExit(1)
+        exit 1
+    }
+
     Write-Host "  ✓ Deployment succeeded!" -ForegroundColor Green
     Write-Host "`n  Outputs:"
     Write-Host "    Flow Log ID:            $($deployment.Outputs['outFlowLogId'].Value)"

--- a/tests/Deployment-State-Gating.Tests.ps1
+++ b/tests/Deployment-State-Gating.Tests.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+    Pester 5 test: a deployment that does not reach 'Succeeded' fails the script that ran it.
+
+.DESCRIPTION
+    Regression guard for issue #75 (AUDIT-modules-2-5.md 5.3).
+
+    'New-AzSubscriptionDeployment' does not throw for every unhappy ending. A deployment
+    whose resources fail to provision can still return an object to the caller - with
+    'ProvisioningState' set to 'Failed' or 'Canceled' - and the pipeline carries on as if
+    nothing happened. A lab script that ignores that value prints its success banner, exits
+    0, and hands the learner a half-built environment; the lab cycle then reports green for
+    a lab that never deployed.
+
+    The contract this file enforces, for every real (non -WhatIf) deployment invocation in
+    the lab scripts:
+
+      captured  The result is assigned to a variable. A deployment piped to Out-Null
+                cannot be inspected at all, so its outcome is unknowable by construction.
+      gated     Some 'if' in the same script tests that variable's 'ProvisioningState'
+                against 'Succeeded', and the branch taken when it does not match ends the
+                script with a non-zero 'exit' (or a 'throw').
+
+    Which branch is the failure branch follows from the operator: '-ne Succeeded' fails in
+    the if body, '-eq Succeeded' fails in the else clause.
+
+    Pairing the guard with the exit code itself is left to Exit-Code-Propagation.Tests.ps1,
+    which separately requires every non-zero 'exit' to be preceded by $Host.SetShouldExit.
+
+.EXAMPLE
+    Invoke-Pester -Path .\tests\Deployment-State-Gating.Tests.ps1
+
+.NOTES
+    Project: SkyCraft
+#>
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+# Every real deployment invocation in a file, with the evidence that its outcome is checked.
+# Parsed rather than regex-matched so that a call spread over several lines, or a name that
+# only appears in a comment, is handled correctly.
+function Get-DeploymentSite {
+    param([string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+
+    $ifStatements = @($ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.IfStatementAst] }, $true))
+
+    foreach ($command in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+
+        $name = $command.GetCommandName()
+        if ($name -notmatch '^New-Az[A-Za-z]*Deployment$') { continue }
+
+        # '-WhatIf' provisions nothing, so there is no provisioning state to gate on.
+        $isWhatIf = @($command.CommandElements | Where-Object {
+            $_ -is [System.Management.Automation.Language.CommandParameterAst] -and $_.ParameterName -eq 'WhatIf'
+        }).Count -gt 0
+        if ($isWhatIf) { continue }
+
+        # The result is captured when the pipeline holding the call is the right-hand side
+        # of an assignment: '$deployment = New-AzSubscriptionDeployment ...'.
+        $variable = ''
+        $node = $command.Parent
+        while ($null -ne $node -and $node -isnot [System.Management.Automation.Language.StatementBlockAst]) {
+            if ($node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                $node.Left -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                $variable = $node.Left.VariablePath.UserPath
+                break
+            }
+            $node = $node.Parent
+        }
+
+        $gated = $false
+        if ($variable) {
+            foreach ($if in $ifStatements) {
+                foreach ($clause in $if.Clauses) {
+
+                    $condition = $clause.Item1.Extent.Text
+                    if ($condition -notmatch ('\$' + [regex]::Escape($variable) + '\b[^\r\n]*\.ProvisioningState')) { continue }
+                    if ($condition -notmatch "Succeeded") { continue }
+
+                    # '-ne Succeeded' fails in the body; '-eq Succeeded' fails in the else.
+                    $failureBranch = if ($condition -match '-(ne|notmatch|cne)\b') {
+                        $clause.Item2
+                    }
+                    elseif ($condition -match '-(eq|ceq)\b') {
+                        $if.ElseClause
+                    }
+
+                    if ($null -eq $failureBranch) { continue }
+
+                    $endsScript = @($failureBranch.FindAll({ param($n)
+                        ($n -is [System.Management.Automation.Language.ExitStatementAst] -and
+                         $null -ne $n.Pipeline -and $n.Pipeline.Extent.Text.Trim() -ne '0') -or
+                        $n -is [System.Management.Automation.Language.ThrowStatementAst]
+                    }, $true)).Count -gt 0
+
+                    if ($endsScript) { $gated = $true }
+                }
+            }
+        }
+
+        [PSCustomObject]@{
+            Line     = $command.Extent.StartLineNumber
+            Variable = $variable
+            Gated    = $gated
+        }
+    }
+}
+
+# Path matching is separator-agnostic so the suite runs identically on the Windows dev box
+# and the Linux CI runner.
+$DeploymentCases = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter '*.ps1' |
+                   Where-Object { (($_.FullName.Substring($RepoRoot.Length + 1)) -replace '\\', '/') -match '^(module-\d.*/)?(scripts|tools)/' } |
+                   ForEach-Object {
+                       $file = $_.FullName.Substring($RepoRoot.Length + 1) -replace '\\', '/'
+                       foreach ($site in Get-DeploymentSite -Path $_.FullName) {
+                           @{
+                               file     = $file
+                               line     = $site.Line
+                               variable = $site.Variable
+                               gated    = $site.Gated
+                           }
+                       }
+                   }
+
+Describe 'SkyCraft PowerShell - a deployment that is not Succeeded fails its script' {
+
+    It "'<file>':<line> assigns the deployment result to a variable" -ForEach $DeploymentCases {
+        # An uncaptured result cannot be inspected, so the failure can never be noticed.
+        $variable | Should -Not -BeNullOrEmpty -Because 'the provisioning state has to be readable to be checked'
+    }
+
+    It "'<file>':<line> exits non-zero when ProvisioningState is not 'Succeeded'" -ForEach $DeploymentCases {
+        # New-Az*Deployment returns a Failed/Canceled deployment instead of throwing, so an
+        # ungated script reports success for a deployment that never completed.
+        $gated | Should -BeTrue -Because "`$$variable.ProvisioningState must be compared with 'Succeeded' and the failing branch must end the script"
+    }
+}


### PR DESCRIPTION
Closes #75 (ProvisioningState gating — the last unchecked box; the CWD/path-anchoring items were done in #93).

## Summary

`New-Az*Deployment` does not throw for every unhappy ending. A deployment whose resources fail to provision still returns an object to the caller — with `ProvisioningState` set to `Failed` or `Canceled` — and the pipeline carries on. A lab script that ignores that value prints its success banner, exits `0`, and hands the learner a half-built environment; the lab cycle then reports green for a lab that never deployed.

This gates the deployment result in the eight scripts that did not, and adds a standards test so it stays gated.

## What changed

**The gap list in the issue was stale.** Re-verified against the current tree: `2.3`, `3.4`, `4.2`, `4.3` and `4.4` were already gated by the earlier retrofits. Five of the eight real gaps were not named in the issue.

| Lab | Gap | Fix |
|---|---|---|
| 1.2 | result piped to `Out-Null` — state never readable | capture `$deployment`, then gate |
| 2.2 | failure branch printed `[FAILED]` and fell through | `exit 1` |
| 3.1 | same | `exit 1` |
| 3.3 | ACR bootstrap deployment uncaptured; main failure branch carried an *"error handling omitted for brevity"* comment instead of a guard | capture + gate both call sites |
| 4.1 | provisioning state printed **in green**, never compared | gate before the success banner |
| 5.1 | retry loop captured the deployment, never checked it | gate after the loop |
| 5.2 | `✓ Vaults deployed successfully!` printed unconditionally | gate inside the non-what-if branch |
| 5.3 | `✓ Deployment succeeded!` printed unconditionally | gate inside the non-what-if branch |

Every guard uses the repo's `$Host.SetShouldExit(1)` + `exit 1` idiom, so a failure also survives `pwsh -File` (#104).

## Regression guard

New `tests/Deployment-State-Gating.Tests.ps1` (34 tests), in the style of `Exit-Code-Propagation.Tests.ps1` — AST-parsed rather than regex-matched, so a call spread over several lines, or a cmdlet name that only appears in a comment, is handled correctly.

For every non-`-WhatIf` `New-Az*Deployment` invocation it requires:

- **captured** — the result is assigned to a variable. A deployment piped to `Out-Null` cannot be inspected at all, so its outcome is unknowable by construction.
- **gated** — some `if` tests that variable's `ProvisioningState` against `'Succeeded'`, and the branch taken when it does not match ends the script. Which branch is the failure branch follows from the operator: `-ne Succeeded` fails in the body, `-eq Succeeded` fails in the else.

Pairing the guard with the exit code itself is left to `Exit-Code-Propagation.Tests.ps1`, so the two rules stay orthogonal.

Documented as rule 6 in `docs/powershell-standards.md`.

## Validation

- `Invoke-Pester ./tests -CI` — **1631 passed**, 5 failed
- `tools/Invoke-DryRun.ps1 -Check Parse,Analyzer` — **PASS**, 0 errors (17 warnings, all pre-existing)

The 5 failures are **pre-existing on `main`** and are in `tools/`, untouched by this PR — 2 × `Cbh-Coverage` and 3 × `Exit-Code-Propagation`, all false positives introduced by #120. Tracked separately in **#124**.

**Not verified:** the issue's *"simulate a failed deployment"* step needs a live subscription, which was out of reach here. What is proven is the static contract plus the existing behavioural exit-code test; an actual failed-deployment run is still unexercised.
