### PR TITLE
docs: point the lab guide template at the Excalidraw contract

### DIFF
--- a/docs/lab-guide-template.md
+++ b/docs/lab-guide-template.md
@@ -39,36 +39,37 @@ By completing this lab, you will:
 
 [ARCHITECTURE_DESCRIPTION — 1-2 sentences describing what the diagram shows]:
 
-```mermaid
-graph TB
-    subgraph "[RESOURCE_GROUP_NAME_1 — e.g. platform-skycraft-swc-rg]"
-        style [STYLE_ID_1] fill:#e1f5ff,stroke:#0078d4,stroke-width:3px
-        [RESOURCE_1]["[RESOURCE_DISPLAY_NAME]<br/>[RESOURCE_DETAILS]"]
-    end
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="images/lab-[X.Y]-architecture.dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="images/lab-[X.Y]-architecture.svg">
+  <img src="images/lab-[X.Y]-architecture.svg" width="100%" alt="Lab [X.Y] architecture: [SHORT_DESCRIPTION]">
+</picture>
 
-    subgraph "[RESOURCE_GROUP_NAME_2 — e.g. dev-skycraft-swc-rg]"
-        style [STYLE_ID_2] fill:#fff4e1,stroke:#f39c12,stroke-width:2px
-        [RESOURCE_2]["[RESOURCE_DISPLAY_NAME]<br/>[RESOURCE_DETAILS]"]
-    end
+<!-- NOTE: the diagram is authored in Excalidraw and committed as three files:
+       images/lab-[X.Y]-architecture.excalidraw     source of truth, hand-editable
+       images/lab-[X.Y]-architecture.svg            light
+       images/lab-[X.Y]-architecture.dark.svg       dark
 
-    subgraph "[RESOURCE_GROUP_NAME_3 — e.g. prod-skycraft-swc-rg]"
-        style [STYLE_ID_3] fill:#ffe1e1,stroke:#e74c3c,stroke-width:2px
-        [RESOURCE_3]["[RESOURCE_DISPLAY_NAME]<br/>[RESOURCE_DETAILS]"]
-    end
+  Two rules are mandatory — see lab-guide-standards.md section 3 and ADR-0004:
+    1. Author at 860 units wide or less. Anything wider is scaled down by GitHub
+       and the body text drops to ~5 px. Stack sections vertically.
+    2. Nothing in the source may be deliberately dark. The dark variant is a
+       colour inversion, so a dark panel inverts to light. Code and evidence
+       panels use fill #e2e8f0, border #cbd5e1, text #166534.
 
-    [RESOURCE_1] -->|"[RELATIONSHIP_LABEL]"| [RESOURCE_2]
-    [RESOURCE_2] -->|"[RELATIONSHIP_LABEL]"| [RESOURCE_3]
-```
+  Render both themes with the excalidraw-diagram skill:
+    cd ~/.claude/skills/excalidraw-diagram/references
+    uv run python render_excalidraw.py --format svg             <file>.excalidraw
+    uv run python render_excalidraw.py --format svg --theme dark <file>.excalidraw
 
-<!-- NOTE: Color scheme MUST follow standard:
-  - Platform/Hub:   fill:#e1f5ff, stroke:#0078d4, stroke-width:3px
-  - Development:    fill:#fff4e1, stroke:#f39c12, stroke-width:2px
-  - Production:     fill:#ffe1e1, stroke:#e74c3c, stroke-width:2px
-  - Key resources:  use accent colors (green #4CAF50, purple #9C27B0, orange #FF9800)
-  Always include resource names following project-standards.md and CIDR ranges for networks.
+  Content: resource group boundaries, names following project-standards.md, CIDR
+  ranges for every network, labelled relationship arrows, and at least one
+  evidence artifact — a real az command, API response, or error string.
 -->
 
-<!-- OPTIONAL: Additional diagrams (e.g. flowcharts for processes, tier transitions) -->
+<!-- OPTIONAL: additional diagrams (process flows, tier transitions) follow the
+     same three-file contract, named after what they show rather than
+     '-architecture', e.g. images/lab-[X.Y]-lifecycle.excalidraw. -->
 
 ---
 
@@ -488,7 +489,7 @@ Before finalizing any lab guide, verify:
 
 - [ ] Title includes lab number and duration
 - [ ] 3-6 clear learning objectives (AZ-104 aligned)
-- [ ] **Mermaid diagram included** with color scheme
+- [ ] **Architecture diagram included** — Excalidraw source + light/dark SVG, ≤860 units wide, embedded via `<picture>`
 - [ ] Real-world scenario provides business context
 - [ ] **SkyCraft Choice** callout included (explains architectural decision)
 - [ ] **Multi-modal instructions** (Portal/CLI/PS) provided where applicable

--- a/module-2-networking/README.md
+++ b/module-2-networking/README.md
@@ -78,7 +78,7 @@ Before starting, ensure you have:
 
 Each lab includes:
 
-- **Lab Guide** - Step-by-step instructions with Mermaid architecture diagrams
+- **Lab Guide** - Step-by-step instructions with architecture diagrams
 - **Lab Checklist** - Verification steps to confirm success
 - **Solutions** - Expected configurations and Azure CLI commands
 - **Troubleshooting** - Common issues and fixes

--- a/module-5-monitoring-maintenance/README.md
+++ b/module-5-monitoring-maintenance/README.md
@@ -81,7 +81,7 @@ az network vnet list --query "[?starts_with(name, 'prod-skycraft')].name" -o tsv
 
 Each lab includes:
 
-- **Lab Guide** (`lab-guide-5.X.md`) — concepts, Mermaid diagram, and multi-modal (Portal + CLI + PowerShell) step-by-step
+- **Lab Guide** (`lab-guide-5.X.md`) — concepts, architecture diagram, and multi-modal (Portal + CLI + PowerShell) step-by-step
 - **Lab Checklist** (`lab-checklist-5.X.md`) — verification-only checkboxes and validation commands
 - **Bicep Templates** (`bicep/`) — `main.bicep` calling Azure Verified Modules, a `parameters/main.bicepparam`, and (Labs 5.1 and 5.2) a local diagnostic-settings fallback under `modules/`
 - **Automation Scripts** (`scripts/`) — `Deploy-Bicep.ps1`, `Test-Lab.ps1`, `Remove-LabResource.ps1`, plus lab-specific helpers


### PR DESCRIPTION
## Summary

Follow-up to #126. That PR replaced all 26 Mermaid diagrams and wrote the Excalidraw contract into `lab-guide-standards.md` §3 — but `docs/lab-guide-template.md` landed on `main` in parallel via #122 and still hands a new lab author a `graph TB` block with the old `#e1f5ff / #fff4e1 / #ffe1e1` palette.

That is the template every new lab is written from, so the first lab created after #126 would have reintroduced Mermaid.

### Changes

- **`docs/lab-guide-template.md`** — the `🏗️ Architecture Overview` section now carries the `<picture>` snippet, the three-file contract (`.excalidraw` + light + dark SVG), both mandatory rules with their reasons, and the render commands. The "optional additional diagrams" note now points at the same contract with a content-based filename rather than `-architecture`.
- **`docs/lab-guide-template.md`** quality checklist — `Mermaid diagram included with color scheme` → the diagram requirement from the standard.
- **`module-2-networking/README.md`**, **`module-5-monitoring-maintenance/README.md`** — prose still describing a lab guide as containing a "Mermaid diagram". Modules 1, 3 and 4 already said "architecture diagrams" or "screenshots" and are untouched.

`CHANGELOG.md` keeps its historical mention of Mermaid — it records what a past release did.

## Related issue

Closes #

## Type of change

- [ ] New lab / content
- [x] Bug fix
- [ ] Enhancement
- [x] Documentation
- [ ] CI / tooling / chore
- [ ] Breaking change

## Pre-merge checklist

- [x] `Test-Lab.ps1` passes for affected lab(s) — no lab scripts touched, three markdown files only
- [x] PSScriptAnalyzer reports 0 errors — no PowerShell touched
- [ ] Pester suite green — see the note below
- [x] All Bicep entry points build — no Bicep touched
- [x] Docs/links updated; directory names match exactly — markdownlint 86 files, 0 issues
- [x] Follows PowerShell & Bicep conventions — n/a

## Note: `main` is currently red, and it is not this PR

`Invoke-Pester ./tests -CI` reports 5 failures on this branch. The identical 5 failures reproduce on a clean worktree of `main` at `d62b8ee`:

```
[-] CBH coverage.'tools\Invoke-LabCycle.ps1' contains a .NOTES tag in the first 60 lines
[-] CBH coverage.'tools\Remove-LabCycle.ps1' contains a .NOTES tag in the first 60 lines
[-] exit code.'tools/Invoke-LabScript.ps1':54 guards 'exit 127' with $Host.SetShouldExit(127)
[-] exit code.'tools/Invoke-LabScript.ps1':65 guards 'exit 126' with $Host.SetShouldExit(126)
[-] exit code.'tools/Invoke-LabScript.ps1':73 guards 'exit $LASTEXITCODE' with $Host.SetShouldExit($LASTEXITCODE)
```

All five are in `tools/`, which this PR does not touch (`git diff main --stat` is three `.md` files). They arrived with #123 / #125, which added the tests and the tooling in parallel. Worth a separate fix.
